### PR TITLE
docs: define ERP shell navigation contract

### DIFF
--- a/docs/app-architecture.md
+++ b/docs/app-architecture.md
@@ -12,6 +12,11 @@ It focuses on routing, layout, rendering boundaries, state placement, and the lo
 - Keep mock REST endpoints under `app/api/**`.
 - Keep the current root-level `app/` structure instead of introducing `src/` during the assignment unless a later change creates a clear need.
 
+## Root Entry Behavior
+
+- In the first pass, `/` should perform a server redirect to `/attendance`.
+- Do not introduce a separate ERP launcher or dashboard home for the current assignment scope.
+
 ## Route Map
 
 ### Employee Routes
@@ -38,26 +43,34 @@ It focuses on routing, layout, rendering boundaries, state placement, and the lo
 
 ## Recommended Route Organization
 
-- Use route groups to separate employee and admin layout concerns without affecting the URL.
+- Use a shared ERP shell layout to host both employee and admin route groups without affecting the URL.
 - A recommended layout shape is:
 
 ```txt
 app/
-  (employee)/
-    attendance/
-      page.tsx
-      leave/
-        page.tsx
-  (admin)/
-    admin/
+  page.tsx
+  (erp)/
+    layout.tsx
+    (employee)/
       attendance/
         page.tsx
-        requests/
+        leave/
           page.tsx
+    (admin)/
+      admin/
+        attendance/
+          page.tsx
+          requests/
+            page.tsx
   api/
     ...
 ```
 
+- `app/page.tsx` should own only the root redirect behavior.
+- `app/(erp)/layout.tsx` should own the shared shell chrome such as the sidebar, restrained top bar, and page frame.
+- The global sidebar should own only the four assignment routes.
+- Keep page-local tabs and filters inside their route UI. Queue views such as `needs_review`, `waiting_for_employee`, `completed`, and `all`, plus attendance history toggles such as week and month, must not become global navigation items.
+- Narrow-width fallback should preserve the same information architecture through a collapsible drawer or sheet pattern instead of a separate mobile route tree.
 - Use private folders such as `_components`, `_lib`, or `_constants` for colocated implementation files that should never become routes.
 
 ## Rendering Boundaries

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -20,6 +20,18 @@ It is a structured interpretation of `docs/raw-assignment.md`, not a verbatim co
 - The product should behave like a trust product rather than a passive ledger: the user should be able to understand the current state, the reason for that state, and the next action without decoding tables first.
 - Employee and admin views must stay synchronized on the same facts for the same date. A date or request must not look resolved on one screen and exceptional on another.
 
+## Shared Shell Contract
+
+- In the first pass, `/` redirects to `/attendance`.
+- The four assignment routes live inside one shared ERP shell rather than separate page-level layouts.
+- The global sidebar contains exactly two route groups:
+  - `Employee`: `/attendance`, `/attendance/leave`
+  - `Admin`: `/admin/attendance`, `/admin/attendance/requests`
+- Global navigation is limited to the four assignment routes in the current scope. Do not expand it into a broader ERP module launcher.
+- `/admin/attendance/requests` owns the queue views `needs_review`, `waiting_for_employee`, `completed`, and `all` as in-page tabs, not as global navigation items.
+- `/attendance` owns week and month history switching as in-page controls, not as global navigation items.
+- Each route inside the shared shell should expose a consistent page header with a page title and brief context line.
+
 ## Employee Flow Requirements
 
 ### Attendance Overview: `/attendance`
@@ -104,6 +116,7 @@ Decision points for later issue planning:
 - Tables and filters should preserve clarity over decoration.
 - Mutations should provide immediate feedback for success and failure.
 - Desktop is the primary experience, but mobile and narrow widths must remain functional.
+- Narrow widths should preserve the same route information architecture by collapsing the shared sidebar into a drawer or sheet instead of introducing a separate mobile navigation tree.
 - Top-of-screen warnings should take priority over buried table-only states when the user needs immediate action.
 - Different causes must remain distinguishable: failed attempt, expected-but-missing check-in, finalized absence, previous-day missing checkout, leave-work conflict, and request-review state must not collapse into one vague warning.
 - Every important state should include the current state, the reason, and the next action.

--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -20,6 +20,15 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 - If a form has a single critical input, that input must receive focus when the form is shown.
 - Dialog UIs must support closing with the `Esc` key.
 
+## Shared Shell Interpretation
+
+- Treat `docs/assets/erp-reference-dashboard.webp` as a reference for the shared ERP chrome, not as a literal module-launcher layout to duplicate.
+- Reuse the reference image's persistent dark sidebar, light content canvas, restrained top utility bar, and white card surfaces.
+- Keep the shared page chrome consistent: each route should present a page title and one brief context line near the top of the content area.
+- Global navigation should stay limited to the four assignment routes. Do not promote request queue views or attendance history view toggles into the sidebar.
+- Narrow-width behavior should preserve the same information architecture through a drawer or sheet version of the sidebar instead of inventing a second mobile IA.
+- Keep the shell visually calm. Avoid decorative dashboards or icon clutter that does not support a real assignment workflow.
+
 ## Exception Surface Rules
 
 - Put active exceptions near the top of the screen before history tables or secondary summaries.
@@ -39,6 +48,12 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 - Warnings should explain why the user is seeing them now, not only what label applies.
 - Use state-specific surfaces for state-specific follow-up. For example, a failed attendance attempt should offer a correction path, while a pending request should offer status visibility rather than a duplicate submission path.
 - After an approval, rejection, resubmission, or successful correction, stale warnings, badges, and CTAs must be replaced or cleared promptly.
+
+## Shell Ownership Rules
+
+- The shared shell owns navigation, overall page framing, and the ERP tone of the application chrome.
+- Attendance and request pages own the active exception state, review state, and next-action messaging that appears inside the shell.
+- Do not use the shell to collapse distinct attendance or request states into one vague global status indicator. Keep those states in each page's top-priority content area.
 
 ## Employee And Admin Tone
 


### PR DESCRIPTION
## Summary
- close `#25` by promoting the ERP shell decision into the canonical docs instead of leaving the shared layout behavior implicit
- define the first-pass root entry contract as `/ -> /attendance`
- define one shared ERP shell with two sidebar route groups and exactly four assignment routes
- define the global-navigation boundary so request queue views and attendance history toggles stay page-local
- define the narrow-width fallback as same-IA drawer/sheet behavior instead of a second mobile navigation structure

## Context
Issue `#25` is the contract gate for the shared shell. Before this PR, the repository already had the route map and the ERP visual direction, but it still did not formally answer the practical questions that block shell implementation:

- what `/` does in the first pass
- how employee and admin routes are grouped in navigation
- whether queue/status subviews belong in global nav or inside each page
- how narrow widths should preserve the shell without inventing a separate mobile IA

This PR intentionally keeps the work docs-only. Runtime implementation belongs to `#27`.

This PR also stays downstream of the already-promoted attendance and request contracts from `#51` and `#54`: it uses those decisions as fixed context rather than reopening state semantics here.

## What This PR Settles
- `/` should server-redirect to `/attendance` in the first pass
- the assignment uses one shared ERP shell instead of ad hoc per-page layouts
- the shared sidebar contains exactly two groups:
  - `Employee`: `/attendance`, `/attendance/leave`
  - `Admin`: `/admin/attendance`, `/admin/attendance/requests`
- `needs_review`, `waiting_for_employee`, `completed`, and `all` stay as page-local tabs within `/admin/attendance/requests`
- attendance week/month switching stays page-local within `/attendance`
- narrow widths preserve the same IA by collapsing the sidebar into a drawer/sheet pattern instead of creating a separate mobile route tree
- the ERP reference image is interpreted as shared application chrome, not as a module-launcher page to duplicate verbatim
- the shared shell owns navigation and framing, while attendance/request pages still own the active exception and next-action messaging inside that shell

## Source-of-Truth Updates
- `docs/app-architecture.md`
  - adds the root-entry contract for `/`
  - upgrades the recommended route organization to include a shared `(erp)` shell layout
  - formalizes the global-nav versus page-local-nav boundary
- `docs/feature-requirements.md`
  - adds a shared shell contract section
  - locks the two-group/four-route sidebar IA
  - records that narrow widths must keep the same IA through a drawer/sheet fallback
- `docs/ui-guidelines.md`
  - explains how to interpret `docs/assets/erp-reference-dashboard.webp`
  - adds shell-level UI guidance for the dark sidebar, restrained top bar, page header, and shell ownership boundaries

## Why The Distinction Matters
Without this PR, `#27` would still need to make product decisions while supposedly only implementing a route skeleton. That would make the first shell implementation an accidental source of truth and increase the risk that later page issues reinterpret navigation locally.

After this PR, the shell implementation can stay implementation-focused because the decisions are already locked in the docs.

## Scope Boundaries
- no runtime shell implementation
- no route skeleton creation
- no `app/page.tsx` change in this PR
- no API, schema, enum, or request-lifecycle changes
- no notification taxonomy work from `#46`
- no collaborative microcopy rules from `#47`
- no page-specific warning hierarchy or stale-state cleanup policy changes

## Downstream References
- closes `#25`
- unblocks `#27` (`ui: implement ERP shell layout and attendance route skeleton`)
- gives a fixed shell contract to the page implementation issues:
  - `#33` (`attendance: build my attendance page with weekly/monthly history and manual request flow`)
  - `#34` (`leave: build leave management page with balance, form, and request history`)
  - `#35` (`admin-attendance: build team attendance dashboard with summary cards, search, and date filters`)
  - `#36` (`requests: build collaborative request review workspace with queue, context, and history`)

## Verification
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`