### PR TITLE
docs: promote leave conflict policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Always consider using the shadcn mcp and shadcn skills first. Follow the mcp and
 - `docs/product-spec-context.md`: living raw product-spec discussion log and cross-screen decision context.
 - `docs/attendance-operating-model.md`: attendance runtime model, time-sequenced fact lifecycle, and shared exception semantics.
 - `docs/request-lifecycle-model.md`: request workflow model, follow-up-chain semantics, and shared employee/admin request synchronization rules.
+- `docs/leave-conflict-policy.md`: leave operational conflict policy, staffing-cap defaults, and company-event warning behavior.
 - `docs/feature-requirements.md`: user-visible scope, roles, screens, and edge cases.
 - `docs/ui-guidelines.md`: implementation-oriented UI guidance that bridges the ERP reference and `DESIGN.md`.
 - `docs/app-architecture.md`: route map, layout boundaries, rendering boundaries, and code organization rules.
@@ -149,6 +150,7 @@ Always consider using the shadcn mcp and shadcn skills first. Follow the mcp and
 - Treat `docs/raw-assignment.md` as a reference input, not as the place to define interpreted contracts.
 - If attendance fact lifecycle, derived exception timing, or cross-screen attendance synchronization rules change, update `docs/attendance-operating-model.md` and any impacted feature/API/schema documents together.
 - If reviewed-request changes, follow-up-chain rules, or shared employee/admin request synchronization rules change, update `docs/request-lifecycle-model.md` and any impacted feature/API/schema documents together.
+- If company-event conflict policy, staffing-cap rules, or leave approval warning behavior changes, update `docs/leave-conflict-policy.md` and any affected feature or UI documents together.
 - If visual direction changes, update both `DESIGN.md` and `docs/ui-guidelines.md`.
 - If route structure or rendering boundaries change, update `docs/app-architecture.md` and any affected user-facing requirements.
 - If payloads, query parameters, or status values change, update `docs/api-spec.md` and `docs/database-schema.md` together.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -18,6 +18,7 @@ These files are meant to guide implementation, issue breakdown, and later mainte
 | `docs/product-spec-context.md`       | living raw product-spec discussion log               | cross-screen spec discussions, locked defaults, or open product questions change                             |
 | `docs/attendance-operating-model.md` | attendance runtime flow and timeline semantics       | attendance fact lifecycle, derived exception timing, or cross-screen attendance synchronization rules change |
 | `docs/request-lifecycle-model.md`    | request workflow semantics and follow-up chains      | reviewed-request change rules, follow-up chains, or cross-screen request synchronization rules change        |
+| `docs/leave-conflict-policy.md`      | leave operational conflict policy                    | company-event conflict, staffing-cap policy, or leave approval warning rules change                          |
 | `docs/feature-requirements.md`       | user-visible features, roles, and edge cases         | screen scope or product behavior changes                                                                     |
 | `docs/ui-guidelines.md`              | ERP-aligned implementation UI guidance               | layout patterns, table rules, badge rules, or responsive behavior changes                                    |
 | `docs/app-architecture.md`           | routing, layout, rendering, and code organization    | route map, layout boundaries, or state-placement rules change                                                |
@@ -34,6 +35,7 @@ These files are meant to guide implementation, issue breakdown, and later mainte
 - `docs/product-spec-context.md` owns the living raw discussion log, cross-screen decision context, and open interview questions that have not yet been promoted into narrower contract documents.
 - `docs/attendance-operating-model.md` owns the attendance fact lifecycle, derived attendance interpretation, and shared attendance timeline semantics.
 - `docs/request-lifecycle-model.md` owns reviewed-request lifecycle semantics, follow-up-chain rules, and shared employee/admin request-state synchronization.
+- `docs/leave-conflict-policy.md` owns company-event conflicts, staffing-cap policy, and leave-specific warning-versus-block defaults across employee and admin review surfaces.
 - `docs/app-architecture.md` owns where routes, layouts, and state boundaries live.
 - `docs/api-spec.md` owns the mock HTTP contract.
 - `docs/database-schema.md` owns the conceptual model and enum vocabulary behind that contract.
@@ -45,6 +47,7 @@ These files are meant to guide implementation, issue breakdown, and later mainte
 - If ongoing product-spec discussions establish new cross-screen principles, preserve raw context in `docs/product-spec-context.md` before promoting final decisions into narrower source-of-truth documents.
 - If the attendance fact lifecycle, exception timing, or cross-screen attendance synchronization rules change, update `docs/attendance-operating-model.md` and any affected contract documents in the same change set.
 - If reviewed-request changes, follow-up-chain semantics, or request-state synchronization rules change, update `docs/request-lifecycle-model.md` and any affected contract documents in the same change set.
+- If company-event conflict policy, staffing-cap rules, or leave approval warning behavior changes, update `docs/leave-conflict-policy.md` and any affected feature or UI docs in the same change set.
 - If a visual rule changes, update `DESIGN.md` and `docs/ui-guidelines.md`.
 - If a route or rendering boundary changes, update `docs/app-architecture.md`.
 - If an API shape changes, update `docs/api-spec.md` and `docs/database-schema.md` together.

--- a/docs/attendance-operating-model.md
+++ b/docs/attendance-operating-model.md
@@ -165,9 +165,9 @@ This document owns attendance flow semantics, not every downstream contract deta
 - `docs/api-spec.md` owns request and response shapes.
 - `docs/database-schema.md` owns the conceptual entity and enum vocabulary.
 - `docs/request-lifecycle-model.md` owns reviewed-request changes, follow-up-chain semantics, and shared request-state synchronization.
+- `docs/leave-conflict-policy.md` owns company-event conflicts, staffing-cap policy, and leave approval warning defaults before attendance facts are interpreted.
 - `docs/product-spec-context.md` keeps raw discussion history and unresolved product questions.
 
 Open questions that remain outside this document:
 
-- staffing-cap policy and company-event calendar policy
 - notification unread, priority, and cleanup rules beyond the attendance flow defaults defined here

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -52,13 +52,15 @@ Required UI:
 - a list of the current user's leave request chains with date, type, reason, current request status, and latest review timing
 - visible prior review comments and follow-up context when a leave request is `revision_requested` or `rejected`
 - a prefilled follow-up path for leave `resubmission`, approved-state `change`, and approved-state `cancel` flows
+- visible pre-submit conflict guidance for company-event-sensitive or staffing-sensitive dates without exposing team-private details; see `docs/leave-conflict-policy.md`
 
-Validation and policy topics that must be handled explicitly in later issues:
+Validation and policy topics that must stay aligned with narrower contract documents:
 
 - whether past-date leave requests are allowed
 - how same-day duplicate requests are prevented
 - how hourly leave should be represented in the UI and payload
 - how approved leave should surface later attendance conflicts without silently overwriting the original leave decision
+- company-event conflict policy and staffing-cap warning behavior should follow `docs/leave-conflict-policy.md`
 
 ## Admin Flow Requirements
 
@@ -90,6 +92,8 @@ Required UI:
 - visible request-chain context that shows the active request, the effective status, and any earlier review comment that still explains the current state
 - post-approval adjustments should route through employee follow-up change or cancel requests rather than an admin-side reversal of the original approval
 - approved-state follow-up `change` and `cancel` flows are in current scope for leave requests only; approved manual-attendance follow-up changes remain out of current scope
+- visible company-event, effective approved leave, pending leave context, and staffing-cap risk before approving a leave request; see `docs/leave-conflict-policy.md`
+- explicit confirmation UI when approving a leave request that still carries a company-event or staffing-cap warning
 
 Decision points for later issue planning:
 

--- a/docs/leave-conflict-policy.md
+++ b/docs/leave-conflict-policy.md
@@ -1,0 +1,98 @@
+# Leave Conflict Policy
+
+## Purpose
+
+This document is the primary source of truth for leave operational conflict policy in the current product.
+It defines how company events, staffing capacity, and approval-side warning behavior influence leave submission and leave review for both employee and admin surfaces.
+
+This document does not own request lifecycle semantics, attendance fact lifecycle, full HTTP payload definitions, or company-event management workflows.
+Those concerns remain in `docs/request-lifecycle-model.md`, `docs/attendance-operating-model.md`, `docs/api-spec.md`, `docs/database-schema.md`, and `docs/product-spec-context.md`.
+
+## First-Pass Policy Defaults
+
+- Treat company-event conflicts as strong warnings, not employee-side hard blocks.
+- Treat staffing-cap risk as warning plus manual admin approval, not automatic employee-side rejection.
+- Evaluate full-day staffing overflow against the currently effective approved leave for the date plus the leave request being reviewed.
+- Keep other pending leave requests visible as review context, but do not treat them as automatic blocking inputs.
+- Keep half-day and hourly leave visible in review context, but do not promote them into first-pass automatic staffing-cap math.
+- Employee surfaces may explain conflict risk qualitatively, but must not expose peer names, exact staffing counts, or other team-private rationale.
+- Admin review surfaces must show company events, effective approved leave, pending leave context, and staffing-cap risk before a leave approval decision.
+- Leave approvals that proceed despite a conflict warning must use explicit confirmation rather than a blind one-click action.
+- Follow-up leave `change` and `cancel` requests continue to use the request-lifecycle model; this document only defines how conflict policy is interpreted around them.
+- Approval, rejection, revision request, resubmission, and approved follow-up outcomes must clear or replace stale warnings, badges, queue rows, and calendar assumptions across employee and admin surfaces.
+
+## Policy Inputs vs Derived Conflict Result
+
+The result labels in this section are policy concepts, not promoted API fields.
+
+| Situation                                                                       | Policy Inputs                                                                                            | Derived Conflict Result           | Required Surface Behavior                                                                                                                                             |
+| ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A leave request targets a workday with a company event                          | The date is still a normal workday, and at least one company event exists on that date                   | company-event warning             | Employees may still submit the request; employee and admin surfaces both show that the date is operationally sensitive rather than silently normal                    |
+| A full-day leave request would stay within the current staffing cap if approved | Effective approved full-day leave plus the current request does not exceed the date's staffing cap       | no automatic cap overflow         | Admin review still shows the approved and pending context for the date, but no cap-overflow confirmation is required                                                  |
+| A full-day leave request would exceed the current staffing cap if approved      | Effective approved full-day leave plus the current request exceeds the date's staffing cap               | staffing-cap overflow warning     | Employees may still submit; admins must see the overflow warning before deciding and must explicitly confirm if they approve anyway                                   |
+| Other leave requests are still pending on the same date                         | One or more same-date leave requests are pending review, but are not yet effective approved leave        | pending-context warning only      | Pending requests stay visible to admins as context and queue pressure, but they do not become automatic blocking math for employee submission or approval             |
+| A half-day or hourly leave request targets a capacity-sensitive date            | The date already has company-event sensitivity, approved leave pressure, pending leave pressure, or both | manual capacity judgment required | The employee sees a qualitative warning; the admin sees same-date context but the system does not pretend to have final automatic capacity math for partial-day cases |
+| The date is a non-workday or company-wide closure                               | `expectedWorkday.isWorkday=false` or equivalent non-workday semantics apply                              | outside this document             | Submission availability and attendance interpretation continue to follow `docs/attendance-operating-model.md` rather than this conflict policy                        |
+
+## Employee Pre-Submit Scenarios
+
+| Moment                                                                                                     | Policy Inputs                                                                              | Policy Result                                   | Required Surface Behavior                                                                                                                                                                                   |
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Employee selects a date with a company event in the leave calendar                                         | Same-day company event exists                                                              | strong warning before submission                | The calendar cell and request entry point indicate that the date is sensitive, and the request form repeats the warning with clear next-action guidance before submit                                       |
+| Employee selects a full-day leave date that would exceed staffing capacity if approved                     | Current effective approved leave plus the new full-day request would exceed the cap        | submit allowed, approval risk highlighted       | The employee is warned that the date has limited staffing capacity and may require stricter review, but the form still allows submission                                                                    |
+| Employee selects a date that already has other pending leave requests                                      | Same-date pending requests exist, but effective approved leave does not yet exceed the cap | context-only warning                            | The employee may be told that the date is under active review pressure, but the product must not imply that another employee has already won the slot                                                       |
+| Employee selects a half-day or hourly leave on a sensitive date                                            | Company-event sensitivity, staffing pressure, or both are present                          | qualitative warning without fake precision      | The employee sees that the date needs closer review, but the surface does not expose exact staffing counts or claim a final capacity decision from partial-day math that the product does not formalize yet |
+| Employee starts a leave `change` or `cancel` follow-up on an already approved request for a sensitive date | The earlier approval is still effective, and the new request is a follow-up                | earlier approval remains effective until review | The employee sees the current approved leave together with the new follow-up and any relevant conflict warning so the product never implies that the change is already approved                             |
+| Employee submits despite a conflict warning                                                                | Warning state existed before submission                                                    | request enters normal pending review            | The request becomes pending review rather than being auto-rejected, and the employee sees that the next step belongs to admin review                                                                        |
+
+## Admin Review Scenarios
+
+| Moment                                                                                              | Policy Inputs                                                                                         | Policy Result                                                                                  | Required Surface Behavior                                                                                                                                                                                             |
+| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Admin opens a leave request on a company-event date                                                 | Same-day company event exists                                                                         | company-event warning                                                                          | The review workspace shows the event context before the admin decides, and the warning is not hidden behind hover-only disclosure                                                                                     |
+| Admin opens a full-day leave request that would exceed the staffing cap if approved                 | Effective approved full-day leave plus the current request exceeds the cap                            | staffing-cap overflow warning                                                                  | The workspace shows the cap risk together with the approved leave already in force, and the approval action requires explicit confirmation                                                                            |
+| Admin opens a date that has multiple pending leave requests                                         | Same-date pending requests exist in addition to the current request                                   | context pressure, not automatic block                                                          | The workspace shows the pending queue pressure as review context, but the admin still evaluates the current request against the effective approved state rather than pretending pending requests are already approved |
+| Admin reviews a half-day or hourly leave request on a sensitive date                                | Partial-day leave is involved on a date with staffing sensitivity, company-event sensitivity, or both | manual judgment remains necessary                                                              | The workspace shows the leave type, time context, and same-date requests, but the system does not claim a final automatic overflow calculation for the partial-day case                                               |
+| Admin reviews a follow-up `change` or `cancel` request while the earlier approval remains effective | The active request is pending, but the effective status for the chain is still the earlier approval   | conflict policy applies to the active review target without hiding the current effective leave | The workspace keeps the effective approved leave visible next to the pending follow-up so the admin can judge operational impact without losing chain context                                                         |
+| Admin approves a warning-bearing leave request                                                      | Company-event warning, staffing-cap warning, or both are present                                      | explicit override-style confirmation                                                           | The confirmation UI repeats the warning context before final approval, and approval immediately refreshes employee/admin surfaces so stale warnings or stale calendar assumptions do not linger                       |
+| Admin rejects or requests revision on a warning-bearing leave request                               | The request carries conflict warnings and the admin decides not to approve it                         | non-approved outcome with rationale                                                            | The admin records a review comment through the existing request-lifecycle model, and the employee sees the rationale together with the next action without any stale pending-state messaging                          |
+
+## Shared Invariants And Forbidden Behaviors
+
+### Shared Invariants
+
+- Leave conflict policy must never silently disagree between employee and admin surfaces for the same date and request chain.
+- Conflict warnings must appear before an approval decision, not only after a decision has already been made.
+- Employee conflict messaging must stay qualitative and collaborative rather than exposing peer-specific internal operations detail.
+- Pending leave requests may shape admin judgment, but they are not equivalent to effective approved leave in first-pass staffing-cap policy.
+- Follow-up leave requests must remain governed by the request-lifecycle model while still inheriting any relevant company-event or staffing-cap context for the reviewed date.
+- A resolved review outcome must clear or replace stale conflict warnings, badges, queue states, and calendar assumptions everywhere the chain appears.
+
+### Forbidden Behaviors
+
+- Do not hard-block employee submission only because a company event exists on an otherwise valid workday.
+- Do not hard-block employee submission only because the date is staffing-sensitive in the current first-pass product.
+- Do not compute staffing-cap overflow as if pending leave requests were already approved.
+- Do not present hover as the only way to access the reason for a company-event or staffing-cap warning.
+- Do not expose peer names, exact staffing counts, or other team-private approval rationale on employee leave surfaces.
+- Do not hide the currently effective approved leave when a pending `change` or `cancel` follow-up is under review.
+- Do not leave stale conflict banners, stale queue states, or stale calendar badges behind after review or follow-up outcomes change the active state.
+
+## Downstream Ownership And Deferred Questions
+
+This document owns leave operational conflict policy, not every downstream contract detail.
+
+- `docs/feature-requirements.md` owns the user-visible expectations for employee leave entry and admin review surfaces.
+- `docs/ui-guidelines.md` owns presentation rules such as disclosure depth, confirmation patterns, warning placement, and message tone.
+- `docs/request-lifecycle-model.md` owns follow-up request chains, review decisions, and shared employee/admin request-state synchronization.
+- `docs/attendance-operating-model.md` owns non-workday semantics, leave coverage inside attendance interpretation, and leave-work conflict handling after attendance facts exist.
+- `docs/api-spec.md` owns any later HTTP projections or field names that expose this policy over the mock API.
+- `docs/database-schema.md` owns any later conceptual entities or vocabulary that formalize this policy in shared data terms.
+- `docs/product-spec-context.md` keeps the raw discussion history and future-policy questions that remain outside this first-pass contract.
+
+Deferred questions that remain outside this document:
+
+- How rich future company-event ownership should become beyond the current read-only seeded inputs
+- When half-day or hourly leave should graduate from admin-reviewed context into formal automatic staffing-cap math
+- Whether any future approval override path should persist explicit override rationale in API or schema fields
+- What notification timing or delivery rules should exist around leave conflict warnings and review outcomes

--- a/docs/product-spec-context.md
+++ b/docs/product-spec-context.md
@@ -48,17 +48,23 @@ This document is a cumulative source-of-truth log for preserving raw product-spe
 - Use that document for reviewed-request immutability, follow-up request chains, revision/change/cancel flows, and shared employee/admin request synchronization rules.
 - Keep this file focused on raw discussion provenance, locked cross-screen principles, and unresolved product questions.
 
+## Promoted Leave Conflict Policy
+
+- The promoted leave operational conflict policy now lives in `docs/leave-conflict-policy.md`.
+- Use that document for company-event conflicts, staffing-cap warning-versus-block defaults, employee pre-submit conflict guidance, and admin approval-side conflict visibility.
+- Keep this file focused on raw discussion provenance, locked cross-screen principles, and unresolved product questions.
+
 ## Open Questions for Future Interviews
 
-- How far should company-event calendars go in the first product scope, and who owns them?
-- Should per-day leave-capacity policy be automatic blocking or warning-plus-manual-approval?
+- How far should future company-event ownership go beyond the current read-only seeded inputs defined in `docs/leave-conflict-policy.md`?
+- When should half-day or hourly leave graduate from admin-reviewed context into formal automatic staffing-cap math?
 - What are the exact triggers, priority rules, cleanup rules, and unread model for in-app notifications?
 - How much leave summary should appear directly on `/attendance`?
 - What is the priority order for exceptions such as previous-day missing checkout, same-day missing check-in, lateness, and revision-requested waiting states?
 - Should any future product phase support exceptional administrative revocation of already approved requests under tightly audited conditions, or should that remain unsupported? See `#53`.
 - Should any future product phase support approved manual-attendance rollback or follow-up change/cancel flows after canonical attendance facts have already been written back?
 - What concrete writing rules should encode the desired collaborative tone and Toss-like microcopy style?
-- When should SLA, company-event conflict warnings, staffing caps, and external notification channels graduate into formal contract documents?
+- When should SLA, external notification channels, or persisted approval-override rationale graduate into formal contract documents?
 
 ## Raw Conversation Archive
 

--- a/docs/request-lifecycle-model.md
+++ b/docs/request-lifecycle-model.md
@@ -247,6 +247,7 @@ This document owns request workflow semantics, not every downstream contract det
 
 - `docs/feature-requirements.md` owns user-visible screen requirements for employee and admin request surfaces.
 - `docs/ui-guidelines.md` owns layout, copy, and interaction guidance for request-related UI.
+- `docs/leave-conflict-policy.md` owns company-event conflicts, staffing-cap policy, and leave approval warning defaults that apply around leave request review.
 - `docs/api-spec.md` owns endpoint shapes, query parameters, and final field names for request lifecycle data.
 - `docs/database-schema.md` owns the conceptual request entities, relations, review-event model, and final enum names.
 - `docs/product-spec-context.md` keeps the raw discussion history and higher-level product rationale that led here.

--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -26,6 +26,7 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 - Surface different causes distinctly. Failed attendance attempts, expected-but-missing check-ins, finalized absences, previous-day missing checkouts, leave-work conflicts, and request-review states must not collapse into one vague warning.
 - If the same fact appears in multiple surfaces such as a summary card, badge, queue row, table row, or CTA panel, those surfaces must agree on the latest state.
 - Do not make hover the primary disclosure mechanism for any important reason, exception, or next action.
+- Use `docs/leave-conflict-policy.md` for the severity and meaning of leave-request conflict states; this file owns only how those states are surfaced.
 
 ## Exception Priority
 
@@ -39,6 +40,8 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 - Warnings should explain why the user is seeing them now, not only what label applies.
 - Use state-specific surfaces for state-specific follow-up. For example, a failed attendance attempt should offer a correction path, while a pending request should offer status visibility rather than a duplicate submission path.
 - After an approval, rejection, resubmission, or successful correction, stale warnings, badges, and CTAs must be replaced or cleared promptly.
+- Employee leave-conflict warnings should communicate operational sensitivity without exposing peer identities or exact staffing counts.
+- Leave approvals that proceed despite a company-event or staffing-cap warning must use explicit confirmation rather than a blind single-click action.
 
 ## Employee And Admin Tone
 
@@ -51,4 +54,5 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 
 - `DESIGN.md` should carry tokens, typography choices, and visual guardrails for design agents.
 - This file should carry implementation guidance for layout, component usage, density, exception priority, and responsive behavior.
+- `docs/leave-conflict-policy.md` should carry leave-specific conflict severity, staffing-cap policy, and approval-warning defaults.
 - If a rule belongs equally to both documents, keep the token-level statement in `DESIGN.md` and the usage rule here.


### PR DESCRIPTION
## Summary
- promote `docs/leave-conflict-policy.md` as the canonical source of truth for leave operational conflict policy
- register the new document in the source-of-truth catalog and narrow adjacent docs so they reference the promoted policy instead of re-defining it locally
- keep conflict-specific API/schema projections out of this PR and defer that follow-up contract work to #56

## What Changed
- add `docs/leave-conflict-policy.md` with first-pass defaults for company-event warnings, staffing-cap warnings, pending-context handling, and explicit confirmation on warning-bearing approvals
- update `AGENTS.md` and `docs/AGENTS.md` so the new document has explicit ownership and update triggers
- align `docs/product-spec-context.md`, `docs/attendance-operating-model.md`, `docs/request-lifecycle-model.md`, `docs/feature-requirements.md`, and `docs/ui-guidelines.md` to the promoted policy boundary
- keep `docs/api-spec.md` and `docs/database-schema.md` unchanged in this docs-first promotion

## Verification
- `pnpm lint`
- `pnpm format:check`

## Notes
- Refs #56
- Closes #48
- Conflict-specific API or schema fields remain intentionally deferred to #56 so the wire contract can be promoted in a synchronized follow-up pass.
