### PR TITLE
infra: add pull request baseline workflow

### DIFF
--- a/.github/workflows/pull-request-baseline.yml
+++ b/.github/workflows/pull-request-baseline.yml
@@ -1,0 +1,51 @@
+name: Pull Request Baseline
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pull-request-baseline-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-baseline:
+    name: pr-baseline
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run lint
+        run: pnpm lint
+
+      - name: Run format check
+        run: pnpm format:check
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Run production build
+        run: pnpm build

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ pnpm test:unit
 pnpm test:integration
 pnpm test:coverage
 pnpm lint
+pnpm format:check
 pnpm build
 ```
 
@@ -40,6 +41,15 @@ This repository uses Lefthook for local Git hooks and does not use Husky.
 - `pre-commit` formats and lints staged files only, then restages safe fixes.
 - `pre-push` runs `pnpm lint`, `pnpm format:check`, `pnpm test`, and
   `pnpm build`.
+
+## Pull Request CI
+
+Pull requests to `main` use the same baseline quality gate as the local `pre-push` hook:
+
+- `pnpm lint`
+- `pnpm format:check`
+- `pnpm test`
+- `pnpm build`
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "attendance-erp",
   "version": "0.1.0",
+  "packageManager": "pnpm@10.33.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- add a single pull-request GitHub Actions workflow that mirrors the local `pre-push` baseline
- declare the repository package manager as `pnpm@10.33.0` for consistent local and CI tooling
- document that pull requests to `main` run the same `lint`, `format:check`, `test`, and `build` gate as local pre-push

## Context
Issue #37 is the minimal infra follow-up that turns the repaired local quality baseline into a GitHub PR gate.

This PR intentionally stays narrow:
- one workflow
- one job name (`pr-baseline`) for a stable required check target
- no docs-only skip logic, no matrix, no Playwright, no deploy automation

Repository branch protection is still a post-merge GitHub settings follow-up because `main` is not currently protected.

## Testing
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm build`

Closes #37
