### PR TITLE
docs: rewrite Korean UX writing contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ This repository is a single-project Next.js 16 App Router application for the Be
 - All repository-wide rules must be defined in the appropriate AGENTS.md.
 - Update the relevant source-of-truth documents in the same change whenever routes, API payloads, data vocabulary, or UI rules change.
 - Write code, comments, and documentation in English.
+- Exception: `docs/ux-writing-guidelines.md` and directly related Korean example copy or tone-rule text may be written in Korean when they exist only to define product wording.
 - Store repository text files with LF line endings. Reserve CRLF only for Windows-only scripts such as `.bat` and `.cmd`.
 - When introducing a workaround, leave sufficient comments that explain why it exists, its scope, and the conditions for removing it.
 - Prefer enum types over strings whenever possible.
@@ -119,7 +120,7 @@ Always consider using the shadcn mcp and shadcn skills first. Follow the mcp and
 - `docs/leave-conflict-policy.md`: leave operational conflict policy, staffing-cap defaults, and company-event warning behavior.
 - `docs/feature-requirements.md`: user-visible scope, roles, screens, and edge cases.
 - `docs/ui-guidelines.md`: implementation-oriented UI guidance that bridges the ERP reference and `DESIGN.md`.
-- `docs/ux-writing-guidelines.md`: implementation-oriented UX writing contract adapted for this product from Toss-style copy rules.
+- `docs/ux-writing-guidelines.md`: Korean UX writing contract adapted for this product from Toss-style copy rules.
 - `docs/app-architecture.md`: route map, layout boundaries, rendering boundaries, and code organization rules.
 - `docs/api-spec.md`: mock API contract for request and response shapes.
 - `docs/database-schema.md`: conceptual data model and shared enum vocabulary.
@@ -154,6 +155,7 @@ Always consider using the shadcn mcp and shadcn skills first. Follow the mcp and
 - If company-event conflict policy, staffing-cap rules, or leave approval warning behavior changes, update `docs/leave-conflict-policy.md` and any affected feature or UI documents together.
 - If visual direction changes, update both `DESIGN.md` and `docs/ui-guidelines.md`.
 - If product copy tone, CTA wording rules, or screen-level writing guidance changes, update `docs/ux-writing-guidelines.md` and any affected UI or feature documents together.
+- Keep `docs/ux-writing-guidelines.md` in Korean unless its ownership changes away from defining product wording.
 - If route structure or rendering boundaries change, update `docs/app-architecture.md` and any affected user-facing requirements.
 - If payloads, query parameters, or status values change, update `docs/api-spec.md` and `docs/database-schema.md` together.
 - Documentation-only phase may mark canonical paths as `planned` before creating path skeletons; create the skeleton in the same change where runtime implementation begins.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -9,23 +9,23 @@ These files are meant to guide implementation, issue breakdown, and later mainte
 
 ### Document Inventory
 
-| File                                 | Primary concern                                      | Update when                                                                                                  |
-| ------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `AGENTS.md`                          | human-readable repository overview and setup         | onboarding or project framing changes                                                                        |
-| `docs/AGENTS.md`                     | documentation catalog and documentation workflow     | docs inventory, ownership, or documentation policy changes                                                   |
-| `DESIGN.md`                          | design-agent visual system                           | design tokens, component style, or visual guardrails change                                                  |
-| `docs/raw-assignment.md`             | raw assignment input and original reference material | the provided assignment text or local visual reference asset changes                                         |
-| `docs/product-spec-context.md`       | living raw product-spec discussion log               | cross-screen spec discussions, locked defaults, or open product questions change                             |
-| `docs/attendance-operating-model.md` | attendance runtime flow and timeline semantics       | attendance fact lifecycle, derived exception timing, or cross-screen attendance synchronization rules change |
-| `docs/request-lifecycle-model.md`    | request workflow semantics and follow-up chains      | reviewed-request change rules, follow-up chains, or cross-screen request synchronization rules change        |
-| `docs/leave-conflict-policy.md`      | leave operational conflict policy                    | company-event conflict, staffing-cap policy, or leave approval warning rules change                          |
-| `docs/feature-requirements.md`       | user-visible features, roles, and edge cases         | screen scope or product behavior changes                                                                     |
-| `docs/ui-guidelines.md`              | ERP-aligned implementation UI guidance               | layout patterns, table rules, badge rules, or responsive behavior changes                                    |
-| `docs/ux-writing-guidelines.md`      | in-product copy contract and CTA wording rules       | tone, CTA wording, question-versus-fact guidance, or copy-specific product rules change                      |
-| `docs/app-architecture.md`           | routing, layout, rendering, and code organization    | route map, layout boundaries, or state-placement rules change                                                |
-| `docs/api-spec.md`                   | mock API contract                                    | endpoint, payload, query parameter, or error contract changes                                                |
-| `docs/database-schema.md`            | conceptual data model and shared enums               | entities, relationships, or shared vocabulary change                                                         |
-| `docs/assets/`                       | documentation image assets                           | a referenced local docs image is added, renamed, or replaced                                                 |
+| File                                 | Primary concern                                       | Update when                                                                                                  |
+| ------------------------------------ | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `AGENTS.md`                          | human-readable repository overview and setup          | onboarding or project framing changes                                                                        |
+| `docs/AGENTS.md`                     | documentation catalog and documentation workflow      | docs inventory, ownership, or documentation policy changes                                                   |
+| `DESIGN.md`                          | design-agent visual system                            | design tokens, component style, or visual guardrails change                                                  |
+| `docs/raw-assignment.md`             | raw assignment input and original reference material  | the provided assignment text or local visual reference asset changes                                         |
+| `docs/product-spec-context.md`       | living raw product-spec discussion log                | cross-screen spec discussions, locked defaults, or open product questions change                             |
+| `docs/attendance-operating-model.md` | attendance runtime flow and timeline semantics        | attendance fact lifecycle, derived exception timing, or cross-screen attendance synchronization rules change |
+| `docs/request-lifecycle-model.md`    | request workflow semantics and follow-up chains       | reviewed-request change rules, follow-up chains, or cross-screen request synchronization rules change        |
+| `docs/leave-conflict-policy.md`      | leave operational conflict policy                     | company-event conflict, staffing-cap policy, or leave approval warning rules change                          |
+| `docs/feature-requirements.md`       | user-visible features, roles, and edge cases          | screen scope or product behavior changes                                                                     |
+| `docs/ui-guidelines.md`              | ERP-aligned implementation UI guidance                | layout patterns, table rules, badge rules, or responsive behavior changes                                    |
+| `docs/ux-writing-guidelines.md`      | Korean in-product copy contract and CTA wording rules | tone, CTA wording, question-versus-fact guidance, or copy-specific product rules change                      |
+| `docs/app-architecture.md`           | routing, layout, rendering, and code organization     | route map, layout boundaries, or state-placement rules change                                                |
+| `docs/api-spec.md`                   | mock API contract                                     | endpoint, payload, query parameter, or error contract changes                                                |
+| `docs/database-schema.md`            | conceptual data model and shared enums                | entities, relationships, or shared vocabulary change                                                         |
+| `docs/assets/`                       | documentation image assets                            | a referenced local docs image is added, renamed, or replaced                                                 |
 
 ### Ownership Matrix
 
@@ -38,7 +38,7 @@ These files are meant to guide implementation, issue breakdown, and later mainte
 - `docs/request-lifecycle-model.md` owns reviewed-request lifecycle semantics, follow-up-chain rules, and shared employee/admin request-state synchronization.
 - `docs/leave-conflict-policy.md` owns company-event conflicts, staffing-cap policy, and leave-specific warning-versus-block defaults across employee and admin review surfaces.
 - `docs/app-architecture.md` owns where routes, layouts, and state boundaries live.
-- `docs/ux-writing-guidelines.md` owns in-product copy tone, CTA wording rules, and question-versus-fact guidance.
+- `docs/ux-writing-guidelines.md` owns in-product copy tone, CTA wording rules, question-versus-fact guidance, and Korean example copy for product wording.
 - `docs/api-spec.md` owns the mock HTTP contract.
 - `docs/database-schema.md` owns the conceptual model and enum vocabulary behind that contract.
 
@@ -52,6 +52,7 @@ These files are meant to guide implementation, issue breakdown, and later mainte
 - If company-event conflict policy, staffing-cap rules, or leave approval warning behavior changes, update `docs/leave-conflict-policy.md` and any affected feature or UI docs in the same change set.
 - If a visual rule changes, update `DESIGN.md` and `docs/ui-guidelines.md`.
 - If product copy tone, CTA wording, or question-versus-fact guidance changes, update `docs/ux-writing-guidelines.md` and any affected UI or feature docs.
+- Repository docs stay English by default. `docs/ux-writing-guidelines.md` and directly related Korean example copy may stay in Korean because they define the product's wording contract itself.
 - If a route or rendering boundary changes, update `docs/app-architecture.md`.
 - If an API shape changes, update `docs/api-spec.md` and `docs/database-schema.md` together.
 - If a terminology change affects multiple documents, update every affected file in one change set.

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -18,6 +18,7 @@ It is a structured interpretation of `docs/raw-assignment.md`, not a verbatim co
 - `docs/attendance-operating-model.md` owns the detailed attendance fact lifecycle and derived exception timing. This document keeps only the user-visible requirements that depend on that lifecycle.
 - `docs/request-lifecycle-model.md` owns reviewed-request changes, follow-up request chains, and cross-screen request-state synchronization. This document keeps only the user-visible requirements that depend on that lifecycle.
 - The product should behave like a trust product rather than a passive ledger: the user should be able to understand the current state, the reason for that state, and the next action without decoding tables first.
+- The product should not feel like a manager-surveillance tool. Both managers and team members should feel that the system helps them align on the same facts and protect themselves from silent mistakes.
 - Employee and admin views must stay synchronized on the same facts for the same date. A date or request must not look resolved on one screen and exceptional on another.
 
 ## Shared Shell Contract
@@ -133,6 +134,8 @@ Decision points for later issue planning:
 - Top-of-screen warnings should take priority over buried table-only states when the user needs immediate action.
 - Different causes must remain distinguishable: failed attempt, expected-but-missing check-in, finalized absence, previous-day missing checkout, leave-work conflict, and request-review state must not collapse into one vague warning.
 - Every important state should include the current state, the reason, and the next action.
+- Korean product copy, CTA wording, and question-versus-fact phrasing should follow `docs/ux-writing-guidelines.md`.
+- The chosen Korean tone should reinforce that the ERP helps both sides do their work accurately and should avoid language that frames the manager as watching people.
 - Warning, badge, and CTA cleanup after approvals, rejections, or successful corrections must happen consistently across employee and admin surfaces.
 - Request surfaces should expose the same active request, effective status, review comment, and next action to both employees and admins.
 

--- a/docs/product-spec-context.md
+++ b/docs/product-spec-context.md
@@ -15,6 +15,7 @@ This document is a cumulative source-of-truth log for preserving raw product-spe
 
 - Treat the product as a trust product, not only a record-keeping tool.
 - Employees and admins should feel like they are aligning on shared facts, not supervising one another.
+- ERP wording and UI framing must not make managers feel like watchers of people or make team members feel watched. The product should feel like a tool that helps both sides protect themselves from silent mistakes.
 - Every screen should show not only the current state, but also why that state exists and what action comes next.
 - Problems must not stay buried inside tables. Today’s state, risk, and next action should be visible near the top of the screen.
 - Silent inconsistency between employee and admin views for the same date or request is not acceptable.
@@ -59,7 +60,8 @@ This document is a cumulative source-of-truth log for preserving raw product-spe
 - The promoted `/attendance` first-view hierarchy now lives in `docs/feature-requirements.md` and `docs/ui-guidelines.md`.
 - Use those documents for the stable today-card model, the separate active-exception stack, exception ordering, carry-over correction entry, and history-action placement.
 - The promoted product-writing contract now lives in `docs/ux-writing-guidelines.md`.
-- Use that document for fact-led warning headlines, action-led CTA wording, and the limited cases where question-form copy is still allowed.
+- Use that document for the Korean tone rules, the Toss-style section structure, fact-led warning headlines, action-led CTA wording, question-versus-fact wording, the limited cases where question-form copy is still allowed, and product-specific copy examples.
+- The choice to follow Toss-style tone is intentional: it is the preferred reference for keeping the ERP collaborative and helpful instead of supervisory or hostile in tone.
 - There are no remaining current-scope open questions in this file for `/attendance` first-view hierarchy or carry-over copy. Future changes to those contracts should start in the primary documents above, with this file used only for new unresolved rationale.
 - The key raw rationale behind those promotions is:
   - the most dangerous attendance problem is a silent error that stays buried in history

--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -67,6 +67,7 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 - Warnings should explain why the user is seeing them now, not only what label applies.
 - Use state-specific surfaces for state-specific follow-up. For example, a failed attendance attempt should offer a correction path, while a pending request should offer status visibility rather than a duplicate submission path.
 - Lead with known facts rather than speculative questions when the product already knows what is wrong. Put any follow-up user-judgment question inside the next step only when the product genuinely needs that judgment.
+- Detailed Korean wording rules, section-by-section tone guidance, and before-and-after copy examples belong in `docs/ux-writing-guidelines.md`.
 - After an approval, rejection, resubmission, or successful correction, stale warnings, badges, and CTAs must be replaced or cleared promptly.
 - Employee leave-conflict warnings should communicate operational sensitivity without exposing peer identities or exact staffing counts.
 - Leave approvals that proceed despite a company-event or staffing-cap warning must use explicit confirmation rather than a blind single-click action.
@@ -81,13 +82,15 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 
 - Employee screens should feel like "protect my day from silent mistakes," not "prove my innocence."
 - Admin screens should feel like "help me resolve operational exceptions," not "rank problem employees."
+- The product should feel like a tool that helps both managers and team members protect accurate records together, not a surveillance surface that turns managers into monitors of people.
 - Event-centered language is preferred over person-centered blame.
 - Keep the next action clear, but do not hide the seriousness of a real issue behind overly soft language.
+- The Korean tone contract in `docs/ux-writing-guidelines.md` intentionally leans on Toss-style voice because that voice reduces surveillance tone while keeping the next action clear.
 
 ## Relationship To `DESIGN.md`
 
 - `DESIGN.md` should carry tokens, typography choices, and visual guardrails for design agents.
 - This file should carry implementation guidance for layout, component usage, density, exception priority, and responsive behavior.
-- `docs/ux-writing-guidelines.md` should carry copy tone, CTA wording, and question-versus-fact rules for in-product text.
+- `docs/ux-writing-guidelines.md` should carry the Korean tone contract, CTA wording rules, question-versus-fact rules, and product-specific copy examples.
 - `docs/leave-conflict-policy.md` should carry leave-specific conflict severity, staffing-cap policy, and approval-warning defaults.
 - If a rule belongs equally to both documents, keep the token-level statement in `DESIGN.md` and the usage rule here.

--- a/docs/ux-writing-guidelines.md
+++ b/docs/ux-writing-guidelines.md
@@ -1,83 +1,243 @@
-# UX Writing Guidelines
+# UX 라이팅 가이드
 
-## Purpose
+## 목적
 
-This document is the primary source of truth for in-product copy in the BestSleep attendance ERP.
-It adapts the relevant parts of Toss UX Writing guidance into a local contract for this repository.
+이 문서는 BestSleep 출결 ERP 안에서 쓰는 문구의 1차 source of truth예요.
+토스 UX 라이팅 원문을 그대로 옮긴 문서가 아니라, 토스의 원칙과 흐름을 이 제품에 맞게 다시 정리한 로컬 계약이에요.
 
-Use this document when writing page headers, status text, warnings, CTA labels, dialogs, helper text, and empty or error states.
-Do not treat the external Toss page as the live contract for this repository after this document is updated.
+페이지 제목, 상태 문구, 경고 문구, CTA, 다이얼로그, 도움말, empty state, error state를 쓸 때 이 문서를 먼저 봐요.
+레이아웃과 surface 배치는 `docs/ui-guidelines.md`가 맡고, 말투와 문구 규칙은 이 문서가 맡아요.
 
-## Source and Scope
+이 문서가 토스 말투를 강하게 참고하는 이유도 분명해요.
+ERP는 잘못 만들면 관리자가 팀원을 감시하는 도구처럼 느껴질 수 있고, 그 순간 제품이 주는 불편과 긴장이 커져요.
+BestSleep ERP는 관리자와 팀원 모두에게 “나를 도와주는 도구”, “같은 사실을 맞추는 도구”처럼 느껴져야 해요.
+그래서 이 문서는 딱딱한 통제형 말투보다, 협업과 정렬의 느낌을 주는 토스식 말투를 더 적합한 기준으로 봐요.
 
-- Source reference reviewed on 2026-04-01: [Toss UX Writing](https://developers-apps-in-toss.toss.im/design/ux-writing.html)
-- This document is an adapted contract, not a verbatim mirror of the external reference.
-- `docs/ui-guidelines.md` owns layout and surface behavior. This document owns wording rules and copy patterns.
+- 원문 참고: [Toss UX Writing](https://developers-apps-in-toss.toss.im/design/ux-writing.html)
+- 검토 기준일: 2026-04-01
+- 이 문서는 원문 미러가 아니라 BestSleep 로컬 계약이에요.
 
-## Core Rules
+## 1. 해요체
 
-- Write product copy in Korean `haeyoche`.
-- Prefer active voice over passive voice unless passive wording makes the user impact clearer or calmer.
-- Prefer positive phrasing over negative phrasing when both are honest and equally clear.
-- Avoid overly formal honorific phrasing such as `-시겠어요?`, `-시나요?`, or person-elevating business phrasing.
-- Prefer verb-led CTA labels over noun-only button labels.
-- CTA labels should describe the user's action, not ask a vague question.
-- Keep the current state, the reason, and the next action visible together when a warning or review state matters operationally.
-- If the product is certain about a fact, lead with the fact instead of a speculative question.
-- Use question-form copy only when the product genuinely needs the user to judge an unknown situation.
-- Avoid blame-oriented wording. State the issue precisely, then show the recovery path.
+제품 안의 문구는 해요체로 써요.
+상황이 급하더라도 명령문처럼 딱딱하게 끊지 말고, 과도하게 높이지도 않아요.
+직원과 관리자가 서로를 감시하는 느낌보다 같은 사실을 맞추는 느낌을 받게 해야 해요.
 
-## CTA Rules
+| 상황                    | 피해야 할 문구   | 권장 문구                                                          |
+| ----------------------- | ---------------- | ------------------------------------------------------------------ |
+| 전날 퇴근 누락 헤드라인 | `퇴근 누락`      | `어제 퇴근 기록이 아직 없어요.`                                    |
+| 출근 누락 안내          | `출근 기록 없음` | `오늘 출근 기록이 아직 없어요.`                                    |
+| 요청 반려 안내          | `반려됨`         | `조정이 필요해요. 사유를 확인하고 수정해서 다시 제출할 수 있어요.` |
+| 관리자 검토 큐          | `문제 직원 3명`  | `오늘 확인이 필요한 근태 3건이 있어요.`                            |
 
-- Default to action-led CTA labels such as `어제 퇴근 시간 정정 요청`, `사유 확인`, or `다시 제출`.
-- Do not use generic CTA labels such as `요청`, `처리`, or `확인` when a more specific verb phrase fits.
-- Do not use top-level CTA buttons that are only speculative questions such as `혹시 퇴근하셨나요?`.
-- When the product knows the factual problem, use a fact-led headline and place any user-judgment question inside the follow-up flow if still needed.
-- Secondary dialog dismissal should use wording equivalent to `닫기` rather than `취소` when the intent is only to leave the dialog.
+## 2. 능동적 말하기
 
-## Attendance-Specific Patterns
+가능한 한 능동형으로 말해요.
+제품이 무엇을 확인했고, 사용자가 지금 무엇을 할 수 있는지 바로 드러나야 해요.
+수동형은 책임을 흐리거나 다음 행동을 숨기기 쉬워요.
 
-### Fact-Led Warning Headlines
+### 됐어요 → 했어요
 
-- Prefer `어제 퇴근 기록이 아직 없어요.` over speculative question-led headlines.
-- Prefer `오늘 출근 기록이 아직 없어요.` over generic missing-record language.
-- Prefer `퇴근 시도가 확인되지 않았어요.` over vague error-only summaries.
+결과만 던지기보다, 누가 어떤 행동을 했는지 보이게 써요.
 
-### Carry-Over Correction Copy
+| 피해야 할 문구            | 권장 문구               |
+| ------------------------- | ----------------------- |
+| `출근 처리가 완료됐어요.` | `출근을 확인했어요.`    |
+| `휴가 신청이 접수됐어요.` | `휴가 신청을 받았어요.` |
+| `반려가 처리됐어요.`      | `검토 결과를 남겼어요.` |
 
-- The top carry-over surface should lead with the factual state first.
-- Use a supportive follow-up explanation such as `이미 퇴근했다면 퇴근 시간을 정정 요청할 수 있어요.`
-- The primary headline can be `어제 퇴근 기록이 아직 없어요.` when the product knows the carry-over problem exists.
-- The default primary CTA should describe the recovery action directly, for example `어제 퇴근 시간 정정 요청`.
-- If the user already has a pending request for the same carry-over problem, replace the duplicate-request CTA with status language such as `상태 확인`.
-- If the user already has a `rejected` or `revision_requested` request for the same carry-over problem, replace the duplicate-request CTA with review or resubmission language such as `사유 확인` or `다시 제출`.
-- Keep speculative questions such as `이미 퇴근하셨나요?` inside the follow-up flow only. Do not use them as the top headline or the primary CTA on the carry-over surface.
+### `~었` 줄이기
 
-### Request-State Copy
+불필요하게 과거형을 겹치지 않아요.
+상태가 지금도 유효하면 지금 시점의 문장처럼 읽히게 써요.
 
-- Use copy that keeps the review reason and the next action together.
-- Prefer `조정이 필요해요. 사유를 확인하고 수정해서 다시 제출할 수 있어요.` over a bare `반려됨`.
-- Keep request status language aligned between employee and admin surfaces so both sides describe the same current state.
-- For a pending carry-over correction, prefer copy such as `어제 퇴근 시간 정정 요청을 검토하고 있어요. 진행 상태를 확인할 수 있어요.`
-- For a rejected or `revision_requested` carry-over correction, prefer copy such as `조정이 필요해요. 사유를 확인하고 수정해서 다시 제출할 수 있어요.`
+| 피해야 할 문구              | 권장 문구                 |
+| --------------------------- | ------------------------- |
+| `정정 요청을 제출했었어요.` | `정정 요청을 제출했어요.` |
+| `사유를 입력해 두셨어요.`   | `사유를 입력했어요.`      |
 
-## Question-Form Exceptions
+### 동사로 바꿔 쓰기
 
-Question-form copy is allowed only when the product cannot determine the answer itself and needs a user judgment.
+명사만 나열하지 말고, 동사로 풀어서 써요.
+특히 CTA와 상태 설명은 사용자가 바로 행동으로 옮길 수 있게 끝을 동사로 여는 편이 좋아요.
 
-Good uses in this product:
+| 피해야 할 문구                          | 권장 문구                                       |
+| --------------------------------------- | ----------------------------------------------- |
+| `근태 이상 확인 필요`                   | `근태 이상을 확인해 주세요.`                    |
+| `반려 사유 확인`만 본문에 반복          | `반려된 이유를 확인하고 다시 제출할 수 있어요.` |
+| `퇴근 누락 정정 요청`을 설명문으로 사용 | `빠진 퇴근 시간을 정정 요청할 수 있어요.`       |
 
-- a confirmation question inside a prefilled carry-over correction flow
-- a user-input prompt where the product genuinely does not know whether the user already completed an action, such as an in-flow confirmation like `이미 퇴근하셨나요?`
+## 3. 긍정적 말하기
 
-Question-form copy should not be the default for:
+부정형을 무조건 금지하는 것은 아니에요.
+다만 사용자가 할 수 있는 행동이나 남아 있는 가능성이 있다면, 그 길을 같이 보여줘요.
+사실을 흐리지 않는 선에서 긍정형으로 말해요.
 
-- known missing-record states
-- top-level warning headlines
-- primary CTA labels
+### 없어요 → 있어요
 
-## Relationship to Other Docs
+| 상황                              | 피해야 할 문구                | 권장 문구                                            |
+| --------------------------------- | ----------------------------- | ---------------------------------------------------- |
+| 같은 날짜에 이미 요청이 있는 경우 | `다시 요청할 수 없어요.`      | `이미 제출한 요청의 상태를 확인할 수 있어요.`        |
+| 휴가 신청이 막힌 날짜             | `이 날짜는 신청할 수 없어요.` | `다른 날짜로 휴가를 신청할 수 있어요.`               |
+| 근태 정정이 검토 중인 경우        | `새 요청을 보낼 수 없어요.`   | `지금은 제출한 요청의 진행 상태를 확인할 수 있어요.` |
 
-- Update `docs/ui-guidelines.md` when copy rules affect surface structure or CTA placement.
-- Update `docs/feature-requirements.md` when copy rules affect user-visible workflow expectations.
-- Keep raw discussion provenance in `docs/product-spec-context.md` when a new writing rule is first debated before it is promoted here.
+### 에러 메시지
+
+에러 문구는 막혔다는 사실만 말하지 말고, 다음 행동을 같이 말해요.
+
+| 상황           | 피해야 할 문구           | 권장 문구                                                                       |
+| -------------- | ------------------------ | ------------------------------------------------------------------------------- |
+| 비콘 검증 실패 | `비콘을 찾을 수 없어요.` | `비콘이 확인되면 출근할 수 있어요. 지금은 정정 요청으로 기록을 남길 수 있어요.` |
+| 퇴근 시도 실패 | `퇴근 실패`              | `퇴근 시도가 확인되지 않았어요. 필요하면 퇴근 시간을 정정 요청할 수 있어요.`    |
+
+::: tip 다이얼로그 왼쪽 버튼은 `닫기`
+다이얼로그 왼쪽 버튼은 `닫기`로 맞춰요.
+`취소`는 사용자가 하던 작업이 취소됐다고 오해할 수 있어요.
+:::
+
+### 서비스를 일부만 쓸 수 있을 때
+
+제품 전체를 못 쓰는 것처럼 읽히지 않게 써요.
+특정 행동만 막혀 있다면, 지금 가능한 행동을 먼저 보여줘요.
+
+| 상황                       | 피해야 할 문구          | 권장 문구                                        |
+| -------------------------- | ----------------------- | ------------------------------------------------ |
+| 검토 중이라 수정 제출 불가 | `수정할 수 없어요.`     | `지금은 검토 중이에요. 상태를 확인할 수 있어요.` |
+| 관리자 검토가 필요한 상태  | `자동 처리되지 않아요.` | `관리자 검토 후 반영돼요.`                       |
+
+## 4. 캐주얼한 경어
+
+`~시겠어요?`, `시나요?`, `~께`, `계시다`, `여쭈다` 같은 과한 경어는 쓰지 않아요.
+사무적이고 딱딱한 말투보다, 친절하지만 가볍게 읽히는 말투가 더 잘 맞아요.
+
+### 동사에서 `~시` 빼기
+
+| 피해야 할 문구              | 권장 문구                                           |
+| --------------------------- | --------------------------------------------------- |
+| `사유를 입력해 주시겠어요?` | `사유를 입력해 주세요.`                             |
+| `다시 제출하시겠어요?`      | `다시 제출할 수 있어요.` 또는 `다시 제출해 주세요.` |
+
+### `계시다` → `있다`
+
+| 피해야 할 문구               | 권장 문구                  |
+| ---------------------------- | -------------------------- |
+| `검토 중이신 요청이 있어요.` | `검토 중인 요청이 있어요.` |
+| `대기 중이신 팀원이 있어요.` | `대기 중인 팀원이 있어요.` |
+
+### `여쭈다` → `확인하다`, `묻다`
+
+| 피해야 할 문구               | 권장 문구                      |
+| ---------------------------- | ------------------------------ |
+| `퇴근 시간을 여쭙고 있어요.` | `퇴근 시간을 확인하고 있어요.` |
+| `사유를 여쭤볼게요.`         | `사유를 물어볼게요.`           |
+
+### `께` → `에게`
+
+| 피해야 할 문구                | 권장 문구                       |
+| ----------------------------- | ------------------------------- |
+| `관리자께 요청을 전달했어요.` | `관리자에게 요청을 전달했어요.` |
+| `팀장님께 확인해 주세요.`     | `팀장에게 확인해 주세요.`       |
+
+### `~시`를 빼면 어색할 때
+
+기계적으로 경어만 빼지 말고, 알고 싶은 정보를 주어로 다시 세워서 써요.
+
+| 피해야 할 문구          | 권장 문구                 |
+| ----------------------- | ------------------------- |
+| `언제 퇴근하셨나요?`    | `퇴근 시간은 언제인가요?` |
+| `어떤 사유로 쉬시나요?` | `쉬는 사유는 무엇인가요?` |
+
+## 5. `{명사} + {명사}` 쓰지 않기
+
+명사를 겹쳐 쓰면 딱딱하고 뜻이 늦게 들어와요.
+한자어 명사는 가능하면 동사나 쉬운 문장으로 풀어 써요.
+
+### 한자어 풀어쓰기
+
+| 피해야 할 문구        | 권장 문구                    |
+| --------------------- | ---------------------------- |
+| `근태 이상 발생`      | `근태 이상이 생겼어요.`      |
+| `요청 반려 처리`      | `요청을 반려했어요.`         |
+| `출근 기록 확인 필요` | `출근 기록을 확인해 주세요.` |
+
+### 풀어쓰기 어려울 때
+
+완전히 바꾸기 어렵다면, 최소한 문장처럼 이어지게 풀어요.
+
+| 피해야 할 문구        | 권장 문구                              |
+| --------------------- | -------------------------------------- |
+| `근태 정정 요청 상태` | `근태 정정 요청이 어디까지 진행됐는지` |
+| `휴가 승인 대기 상태` | `휴가 신청을 지금 검토하고 있는 상태`  |
+
+## 6. 예외 규칙
+
+기본 규칙을 그대로 쓰면 오히려 어색하거나 덜 정확한 경우가 있어요.
+아래 경우만 예외를 허용해요.
+
+### 질문형은 제품이 답을 모를 때만 써요
+
+질문형은 제품이 이미 답을 아는 상황에서 쓰지 않아요.
+특히 top headline과 primary CTA에서는 질문형을 금지해요.
+
+| 상황                     | 피해야 할 문구       | 권장 문구                       |
+| ------------------------ | -------------------- | ------------------------------- |
+| 전날 퇴근 누락 헤드라인  | `혹시 퇴근하셨나요?` | `어제 퇴근 기록이 아직 없어요.` |
+| carry-over CTA           | `퇴근하셨나요?`      | `어제 퇴근 시간 정정 요청`      |
+| follow-up flow 내부 확인 | `-`                  | `이미 퇴근했나요?`              |
+
+질문형을 써도 되는 경우:
+
+- 제품이 사용자의 판단 없이는 사실을 확정할 수 없을 때
+- prefilled follow-up flow 안에서 마지막 확인이 필요할 때
+- 입력을 시작하기 전에 사용자의 선택을 받아야 할 때
+
+### 사실형 헤드라인 + 행동형 CTA를 같이 써요
+
+제품이 문제를 이미 알고 있다면, 헤드라인은 사실을 말하고 CTA는 행동을 말해요.
+
+| 상황           | 헤드라인                         | 보조 문구                                            | CTA                        |
+| -------------- | -------------------------------- | ---------------------------------------------------- | -------------------------- |
+| 전날 퇴근 누락 | `어제 퇴근 기록이 아직 없어요.`  | `이미 퇴근했다면 퇴근 시간을 정정 요청할 수 있어요.` | `어제 퇴근 시간 정정 요청` |
+| 오늘 출근 누락 | `오늘 출근 기록이 아직 없어요.`  | `출근이 늦어졌거나 기록이 빠졌다면 확인해 주세요.`   | `출근 기록 확인`           |
+| 퇴근 시도 실패 | `퇴근 시도가 확인되지 않았어요.` | `필요하면 퇴근 시간을 정정 요청할 수 있어요.`        | `퇴근 시간 정정 요청`      |
+
+### carry-over 요청 상태는 상태에 맞게 CTA를 바꿔요
+
+같은 문제로 이미 요청이 있으면, 새 요청을 권하지 않아요.
+
+| 상태                 | 헤드라인 예시                       | 본문 예시                                           | CTA 예시    |
+| -------------------- | ----------------------------------- | --------------------------------------------------- | ----------- |
+| `pending`            | `어제 퇴근 기록을 확인하고 있어요.` | `제출한 정정 요청의 진행 상태를 확인할 수 있어요.`  | `상태 확인` |
+| `rejected`           | `조정이 필요해요.`                  | `사유를 확인하고 수정해서 다시 제출할 수 있어요.`   | `사유 확인` |
+| `revision_requested` | `보완이 필요해요.`                  | `남긴 사유를 확인하고 수정해서 다시 제출해 주세요.` | `다시 제출` |
+
+### 검토 결과는 이유와 다음 행동을 같이 보여줘요
+
+상태 이름만 던지지 말고, 왜 그런지와 다음 행동을 같이 보여줘요.
+
+| 피해야 할 문구 | 권장 문구                                                          |
+| -------------- | ------------------------------------------------------------------ |
+| `반려됨`       | `조정이 필요해요. 사유를 확인하고 수정해서 다시 제출할 수 있어요.` |
+| `보완 요청`    | `보완이 필요해요. 남긴 사유를 확인하고 다시 제출해 주세요.`        |
+| `승인 대기`    | `검토 중이에요. 진행 상태를 확인할 수 있어요.`                     |
+
+### 부드럽지만 흐리지 않게 써요
+
+이 제품은 협업 도구처럼 말해야 하지만, 문제의 심각성을 감추면 안 돼요.
+비난하지 않되, 사실과 다음 행동은 분명하게 남겨요.
+
+| 피해야 할 문구                        | 권장 문구                                                          |
+| ------------------------------------- | ------------------------------------------------------------------ |
+| `문제 직원 3명`                       | `오늘 확인이 필요한 근태 3건이 있어요.`                            |
+| `지각자를 관리하세요.`                | `지금 확인이 필요한 근태를 먼저 살펴봐요.`                         |
+| `누락됐지만 나중에 처리할 수 있어요.` | `기록이 빠졌어요. 지금 정정 요청을 남기면 더 빨리 맞출 수 있어요.` |
+
+이 원칙의 목적은 분위기를 무조건 부드럽게 만드는 데 있지 않아요.
+관리자와 팀원 모두가 이 시스템을 “나를 통제하는 도구”가 아니라 “실수를 빨리 맞추고 일을 덜 꼬이게 해 주는 도구”로 느끼게 만드는 데 있어요.
+
+## 다른 문서와의 관계
+
+- 레이아웃, surface 우선순위, interaction 규칙은 `docs/ui-guidelines.md`를 따라요.
+- 사용자에게 보여야 하는 동작과 흐름은 `docs/feature-requirements.md`를 따라요.
+- 말투 규칙이 처음 논의된 배경이나 아직 승격 전인 논의는 `docs/product-spec-context.md`에 남겨요.
+- 이 문서의 규칙을 바꾸면 관련된 UI/feature 문서도 같은 변경에서 같이 맞춰요.


### PR DESCRIPTION
﻿## Summary
This stacked PR rewrites the product writing contract into Korean while keeping the rest of the source-of-truth docs in English.

It keeps the page-local attendance contract from #62 and changes only the wording contract and adjacent references.

## What Changed
- Rebuilt `docs/ux-writing-guidelines.md` as a Korean source-of-truth document that follows the Toss UX writing structure closely while staying adapted to BestSleep ERP.
- Added product-specific examples for attendance warnings, carry-over correction, request states, admin review wording, and dialog buttons.
- Recorded the reason for following Toss-style tone: the ERP should feel like a tool that helps both managers and team members, not a surveillance surface.
- Updated adjacent docs to treat the Korean writing contract as the authoritative place for tone, CTA wording, and question-versus-fact rules.
- Added a narrow repository exception so Korean is allowed for `docs/ux-writing-guidelines.md` and directly related Korean wording examples.

## Docs Updated
- `AGENTS.md`
- `docs/AGENTS.md`
- `docs/feature-requirements.md`
- `docs/product-spec-context.md`
- `docs/ui-guidelines.md`
- `docs/ux-writing-guidelines.md`

## Base / Scope Notes
- Base branch: `codex/finalize-attendance-page-local-hierarchy-contract`
- This PR is stacked on top of #62 because it touches the same documentation set.
- No runtime code, API contract, schema, or UI hierarchy behavior changes are included here.

## Verification
- `pnpm lint`
- `pnpm format:check`
- pre-push `next build`
- pre-push `pnpm test`
