### PR TITLE
docs: remove waiting_for_employee queue concept and reframe non-approved review history

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -94,14 +94,12 @@ This document owns endpoint shapes and final field names, not the broader workfl
 ### Request Queue View
 
 - `needs_review`
-- `waiting_for_employee`
 - `completed`
 - `all`
 
 ### Request Next Action
 
 - `admin_review`
-- `employee_resubmit`
 - `none`
 
 ### Manual Attendance Action
@@ -205,7 +203,7 @@ Fields:
 
 `status` uses `Request Status`.
 `reviewComment` is `null` unless the latest review event used `reject` or `request_revision`.
-`governingReviewComment` is the latest unresolved `reject` or `request_revision` rationale that must remain visible while the employee still owes a response; otherwise it is `null`.
+`governingReviewComment` is the latest unresolved `reject` or `request_revision` rationale that must remain visible while a linked follow-up has not yet resolved that reviewed outcome; otherwise it is `null`.
 Attendance endpoints surface only `pending`, `revision_requested`, or `rejected` here.
 Approved manual requests do not remain embedded here after their changes are written back into the canonical attendance record.
 
@@ -225,9 +223,11 @@ Fields:
 
 `activeRequestId` and `activeStatus` are `null` when a chain has no active work.
 `effectiveStatus` uses `Request Status`.
-`effectiveRequestId` and `effectiveStatus` point to the current non-approved reviewed request while no employee follow-up exists. After an employee submits a linked `resubmission`, they move to the new pending follow-up while the earlier review rationale remains visible through linked chain history or parent-request context.
-`governingReviewComment` stays populated only while the employee still owes a response to the latest non-approved review rationale; otherwise it is `null`.
+When a chain is `rejected` or `revision_requested` with no active follow-up, `activeRequestId` and `activeStatus` are `null`, while `effectiveRequestId` and `effectiveStatus` still point to the latest reviewed outcome and `nextAction = none`.
+After an employee submits a linked `resubmission`, `active*` and `effective*` move to the new pending follow-up while the earlier review rationale remains visible through linked chain history or parent-request context.
+`governingReviewComment` stays populated only while the latest non-approved reviewed outcome has not yet been resolved by a linked follow-up; otherwise it is `null`.
 `nextAction` uses `Request Next Action`.
+Employee pages may still expose linked `resubmission` entry points from request status and relation fields even though the shared projection no longer treats the reviewed non-approved step as active work.
 
 ### `Request Relation Fields`
 
@@ -863,16 +863,17 @@ Returns the request-review queue for admins.
 
 Query parameters:
 
-- `view`: optional `needs_review`, `waiting_for_employee`, `completed`, or `all`
+- `view`: optional `needs_review`, `completed`, or `all`
 
 Response notes:
 
 - each item uses `Request Status` plus relation fields and the shared `Request Chain Projection`
 - `reviewComment` is `null` unless the latest review event used `reject` or `request_revision`
-- `governingReviewComment` stays populated when the currently visible chain state still owes a response to an earlier non-approved review comment
+- `governingReviewComment` stays populated while the latest non-approved reviewed outcome has not yet been resolved by a linked follow-up
 - `needs_review` groups chains whose active request has `status = pending`
-- `waiting_for_employee` groups chains whose effective status is `revision_requested` or `rejected` and which have no active follow-up
-- `completed` groups chains whose effective status is `approved` or `withdrawn` and which have no active follow-up
+- `completed` groups chains whose effective status is `approved`, `withdrawn`, `revision_requested`, or `rejected` and which have no active follow-up
+- `all` includes both actionable review work and completed review history
+- admin clients may visually separate reviewed non-approved items from approved or withdrawn results inside `completed` and `all`
 - request-chain semantics, reviewed-request immutability, and follow-up workflow rules are defined in `docs/request-lifecycle-model.md`
 
 Response:
@@ -948,12 +949,12 @@ Response:
   "reviewedAt": "2026-03-30T13:15:00+09:00",
   "reviewComment": "Please clarify the missing clock-out time.",
   "governingReviewComment": "Please clarify the missing clock-out time.",
-  "activeRequestId": "req_manual_001",
-  "activeStatus": "revision_requested",
+  "activeRequestId": null,
+  "activeStatus": null,
   "effectiveRequestId": "req_manual_001",
   "effectiveStatus": "revision_requested",
   "hasActiveFollowUp": false,
-  "nextAction": "employee_resubmit"
+  "nextAction": "none"
 }
 ```
 
@@ -962,7 +963,7 @@ Typical error cases:
 - `400 validation_error` for invalid decision payloads
 - `404 not_found` when the request id does not exist
 - `409 conflict` when the request is `rejected`, `revision_requested`, `approved`, `withdrawn`, superseded, or otherwise not writable under the current request-lifecycle rules
-- `409 conflict` should explain when a reviewed request is locked and that employee resubmission is required before the chain becomes writable again
+- `409 conflict` should explain when a reviewed request remains locked on the same record and that any later resubmission must use a linked follow-up rather than reopening the reviewed request in place
 
 ## Change Triggers
 

--- a/docs/app-architecture.md
+++ b/docs/app-architecture.md
@@ -69,7 +69,7 @@ app/
 - `app/page.tsx` should own only the root redirect behavior.
 - `app/(erp)/layout.tsx` should own the shared shell chrome such as the sidebar, restrained top bar, and page frame.
 - The global sidebar should own only the four assignment routes.
-- Keep page-local tabs and filters inside their route UI. Queue views such as `needs_review`, `waiting_for_employee`, `completed`, and `all`, plus attendance history toggles such as week and month, must not become global navigation items.
+- Keep page-local tabs and filters inside their route UI. Queue views such as `needs_review`, `completed`, and `all`, plus attendance history toggles such as week and month, must not become global navigation items.
 - Keep `/admin/attendance` today and history switching inside the same route as page-local view state instead of creating additional child routes for those modes.
 - Narrow-width fallback should preserve the same information architecture through a collapsible drawer or sheet pattern instead of a separate mobile route tree.
 - Use private folders such as `_components`, `_lib`, or `_constants` for colocated implementation files that should never become routes.

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -85,14 +85,12 @@ This document owns the conceptual entities and final enum names, not the broader
 ### Request Queue View
 
 - `needs_review`
-- `waiting_for_employee`
 - `completed`
 - `all`
 
 ### Request Next Action
 
 - `admin_review`
-- `employee_resubmit`
 - `none`
 
 ### Manual Attendance Action
@@ -262,24 +260,24 @@ In the current product, a request record gets at most one review event because r
 Represents the endpoint-facing attendance projection for the manual request that still matters to the current attendance state, including prior-workday carry-over corrections.
 This is derived from `Manual Attendance Request` rather than persisted as a second source of truth.
 
-| Field                    | Type           | Notes                                                                                                                        |
-| ------------------------ | -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `id`                     | string         | stable request identifier                                                                                                    |
-| `action`                 | enum           | `Manual Attendance Action`                                                                                                   |
-| `date`                   | string         | target workday                                                                                                               |
-| `requestedAt`            | string         | employee submission timestamp                                                                                                |
-| `status`                 | enum           | `Request Status`; attendance endpoints surface only `pending`, `revision_requested`, or `rejected`                           |
-| `reviewComment`          | string or null | non-empty string when the latest review event used `reject` or `request_revision`                                            |
-| `governingReviewComment` | string or null | latest unresolved `reject` or `request_revision` rationale that must remain visible while employee response is still pending |
-| `rootRequestId`          | string         | root request in the chain                                                                                                    |
-| `parentRequestId`        | string or null | immediate prior request for a follow-up                                                                                      |
-| `followUpKind`           | enum or null   | only `resubmission` is in current scope for manual attendance follow-ups                                                     |
-| `activeRequestId`        | string or null | chain-level active request                                                                                                   |
-| `activeStatus`           | enum or null   | chain-level active status                                                                                                    |
-| `effectiveRequestId`     | string         | request whose current status governs the chain                                                                               |
-| `effectiveStatus`        | enum           | chain-level effective status                                                                                                 |
-| `hasActiveFollowUp`      | boolean        | whether an employee-submitted follow-up is currently active                                                                  |
-| `nextAction`             | enum           | `Request Next Action`                                                                                                        |
+| Field                    | Type           | Notes                                                                                                                                                   |
+| ------------------------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                     | string         | stable request identifier                                                                                                                               |
+| `action`                 | enum           | `Manual Attendance Action`                                                                                                                              |
+| `date`                   | string         | target workday                                                                                                                                          |
+| `requestedAt`            | string         | employee submission timestamp                                                                                                                           |
+| `status`                 | enum           | `Request Status`; attendance endpoints surface only `pending`, `revision_requested`, or `rejected`                                                      |
+| `reviewComment`          | string or null | non-empty string when the latest review event used `reject` or `request_revision`                                                                       |
+| `governingReviewComment` | string or null | latest unresolved `reject` or `request_revision` rationale that must remain visible while a linked follow-up has not yet resolved that reviewed outcome |
+| `rootRequestId`          | string         | root request in the chain                                                                                                                               |
+| `parentRequestId`        | string or null | immediate prior request for a follow-up                                                                                                                 |
+| `followUpKind`           | enum or null   | only `resubmission` is in current scope for manual attendance follow-ups                                                                                |
+| `activeRequestId`        | string or null | chain-level active request                                                                                                                              |
+| `activeStatus`           | enum or null   | chain-level active status                                                                                                                               |
+| `effectiveRequestId`     | string         | request whose current status governs the chain                                                                                                          |
+| `effectiveStatus`        | enum           | chain-level effective status                                                                                                                            |
+| `hasActiveFollowUp`      | boolean        | whether an employee-submitted follow-up is currently active                                                                                             |
+| `nextAction`             | enum           | `Request Next Action`                                                                                                                                   |
 
 ### Request Chain Projection
 
@@ -297,8 +295,10 @@ Expected fields:
 
 Important rules:
 
-- When a chain is `rejected` or `revision_requested` with no active follow-up, `effectiveRequestId` and `effectiveStatus` point to that reviewed request and `nextAction = employee_resubmit`.
+- When a chain is `rejected` or `revision_requested` with no active follow-up, `activeRequestId` and `activeStatus` are `null`, while `effectiveRequestId` and `effectiveStatus` still point to that reviewed request and `nextAction = none`.
 - When an employee submits a linked `resubmission`, `activeRequestId`, `activeStatus`, `effectiveRequestId`, and `effectiveStatus` move to the new pending follow-up while the earlier non-approved rationale may remain visible through linked request history or parent-request context.
+- `governingReviewComment` stays populated only while the latest non-approved reviewed outcome has not yet been resolved by a linked follow-up; otherwise it is `null`.
+- Employee pages may still expose linked `resubmission` entry points from request status and relation fields even though the shared projection no longer treats the reviewed non-approved step as active work.
 
 ### Attendance Display
 

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -8,7 +8,7 @@ It is a structured interpretation of `docs/raw-assignment.md`, not a verbatim co
 ## Roles
 
 - **Employee**: views personal attendance facts and active exceptions, submits manual attendance requests, and manages leave requests.
-- **Admin**: monitors team attendance, reviews current exceptions, and reviews request work across needs-review, waiting-for-employee, and completed states.
+- **Admin**: monitors team attendance, reviews current exceptions, and reviews actionable request work plus completed review history across `needs_review`, `completed`, and `all` contexts.
 
 ## Shared Product Rules
 
@@ -28,7 +28,7 @@ It is a structured interpretation of `docs/raw-assignment.md`, not a verbatim co
   - `Employee`: `/attendance`, `/attendance/leave`
   - `Admin`: `/admin/attendance`, `/admin/attendance/requests`
 - Global navigation is limited to the four assignment routes in the current scope. Do not expand it into a broader ERP module launcher.
-- `/admin/attendance/requests` owns the queue views `needs_review`, `waiting_for_employee`, `completed`, and `all` as in-page tabs, not as global navigation items.
+- `/admin/attendance/requests` owns the queue views `needs_review`, `completed`, and `all` as in-page tabs, not as global navigation items.
 - `/attendance` owns week and month history switching as in-page controls, not as global navigation items.
 - Each route inside the shared shell should expose a consistent page header with a page title and brief context line.
 
@@ -61,7 +61,7 @@ Edge cases to keep visible during implementation:
 - the user sees a previous-day missing checkout and should be led into correction without needing to decode the history table first
 - the previous day's record is still open because checkout is missing
 - the user has a rejected or `revision_requested` manual request and should see the review reason plus a resubmission path above history
-- the user should be told that a reviewed non-approved manual request is no longer admin-writable on the same request record and now awaits employee resubmission
+- the user should be told that a reviewed non-approved manual request is no longer admin-writable on the same request record and should instead offer a clear employee-side resubmission path when correction is still needed
 - the user has both an unresolved failed attendance attempt and a same-day expected-but-missing check-in state and should see those causes as separate exception surfaces
 - an approved leave day later conflicts with an actual attendance fact and must surface as a visible conflict instead of silently rewriting either fact
 
@@ -73,7 +73,7 @@ Required UI:
 - a request form for annual leave, half-day AM, half-day PM, and hourly leave
 - a list of the current user's leave request chains with date, type, reason, current request status, and latest review timing
 - visible prior review comments and follow-up context when a leave request is `revision_requested` or `rejected`
-- reviewed non-approved leave requests should read as completed admin review awaiting employee resubmission; `revision_requested` should emphasize correction guidance, while `rejected` should emphasize refusal of the current version without removing the linked resubmission path
+- reviewed non-approved leave requests should read as completed admin review with a clear employee-side resubmission path; `revision_requested` should emphasize correction guidance, while `rejected` should emphasize refusal of the current version without removing the linked resubmission path
 - a prefilled follow-up path for leave `resubmission`, approved-state `change`, and approved-state `cancel` flows
 - visible pre-submit conflict guidance for company-event-sensitive or staffing-sensitive dates without exposing team-private details; see `docs/leave-conflict-policy.md`
 
@@ -121,11 +121,14 @@ Edge cases to keep visible during implementation:
 Required UI:
 
 - a request table covering manual attendance requests and leave requests
-- filter tabs for needs review, waiting for employee, completed, and all
+- filter tabs for needs review, completed, and all
 - approve, reject, and request-revision actions with confirmation UI
 - explicit review-comment input when rejecting a request or requesting revision
 - visible request-chain context that shows the active request, the effective status, and any earlier review comment that still explains the current state
-- reviewed non-approved requests should be described as completed admin review awaiting employee resubmission rather than as admin-writable pending work on the same request record
+- reviewed non-approved requests should be described as completed review history on the admin side rather than as admin-writable pending work on the same request record
+- reviewed non-approved requests should appear in `completed` and `all` only, never in `needs_review`
+- within `completed` and `all`, reviewed non-approved requests should remain visible as history/context rather than as a separate admin queue state
+- admin-side next action for reviewed non-approved history should be treated as no further admin action on the same record, even when employee pages still expose a page-local resubmission path
 - post-approval adjustments should route through employee follow-up change or cancel requests rather than an admin-side reversal of the original approval
 - approved-state follow-up `change` and `cancel` flows are in current scope for leave requests only; approved manual-attendance follow-up changes remain out of current scope
 - visible company-event, effective approved leave, pending leave context, and staffing-cap risk before approving a leave request; see `docs/leave-conflict-policy.md`
@@ -149,8 +152,9 @@ Decision points for later issue planning:
 - Different causes must remain distinguishable: failed attempt, expected-but-missing check-in, finalized absence, previous-day missing checkout, leave-work conflict, and request-review state must not collapse into one vague warning.
 - Every important state should include the current state, the reason, and the next action.
 - Warning, badge, and CTA cleanup after approvals, rejections, or successful corrections must happen consistently across employee and admin surfaces.
-- Request surfaces should expose the same active request, effective status, review comment, and next action to both employees and admins.
-- Employee and admin surfaces must interpret `rejected` and `revision_requested` as locked non-approved reviewed states whose next action remains employee resubmission until a linked follow-up exists.
+- Request surfaces should expose the same active request, effective status, and review comment to both employees and admins, while employee resubmission prompting may remain page-local.
+- On admin completed-history surfaces, the "next action" rule should not be interpreted as employee-resubmit guidance inside the admin workspace; those surfaces should read as no further admin action on the same record.
+- Employee and admin surfaces must interpret `rejected` and `revision_requested` as locked non-approved reviewed states on the same request record until a linked follow-up exists. Employee pages may promote resubmission entry points, while admin pages should treat those reviewed outcomes as completed review history rather than active queue work.
 
 ## Out Of Scope
 

--- a/docs/product-spec-context.md
+++ b/docs/product-spec-context.md
@@ -30,6 +30,9 @@ This document is a cumulative source-of-truth log for preserving raw product-spe
 - The earlier remediation wording in this section should now be read as historical pre-promotion context, not as an active contract rule.
 - Re-submission after rejection should start from a prefilled version of the previous input rather than an empty form.
 - A reviewed non-approved request is now treated as locked on the same request record: admins do not append a later review outcome to that record, and the chain reactivates only through an employee-submitted `resubmission` follow-up.
+- A reviewed non-approved request with no active follow-up is no longer treated as shared active work. The latest reviewed outcome still remains visible as chain history, but shared queue-state vocabulary should not model it as `waiting_for_employee`.
+- Any remaining `waiting_for_employee` mention in this document should be read as historical or rejected-alternative vocabulary only, not as active source-of-truth terminology.
+- Employee-facing resubmission prompting remains valid for reviewed non-approved requests, but that prompting now belongs to page IA rather than shared request queue-state semantics.
 - Any earlier direction that suggested same-record revision of a `rejected` or `revision_requested` request should now be read as superseded discussion history rather than active contract.
 - Notification scope is in-app first: warnings, badges, and status surfaces come before external push channels.
 - Employee and admin views must stay synchronized on the same facts and statuses, with stale states cleared promptly.
@@ -48,7 +51,8 @@ This document is a cumulative source-of-truth log for preserving raw product-spe
 - The promoted request-lifecycle contract now lives in `docs/request-lifecycle-model.md`.
 - Use that document for request statuses, follow-up kinds, review decisions, queue views, and shared request projection rules.
 - Use that document for reviewed-request immutability, follow-up request chains, revision/change/cancel flows, and shared employee/admin request synchronization rules.
-- Keep issue `#41` focused on leave-page IA, issue `#42` focused on review-workspace IA, issue `#64` focused on queue placement and non-approved visibility grouping, and issue `#66` focused on leave top-surface suppression semantics.
+- Keep issue `#41` focused on leave-page IA, issue `#42` focused on review-workspace IA under the updated admin queue contract, issue `#64` focused on removing `waiting_for_employee` and promoting non-approved reviewed requests into completed review history on admin surfaces, and issue `#66` focused on leave top-surface suppression semantics.
+- The rejected alternatives behind issue `#64` are: keep a standalone `waiting_for_employee` admin queue, or add a separate source-of-truth document instead of promoting the decision into the existing canonical request documents.
 - Keep this file focused on raw discussion provenance, locked cross-screen principles, and unresolved product questions.
 
 ## Promoted Leave Conflict Policy

--- a/docs/request-lifecycle-model.md
+++ b/docs/request-lifecycle-model.md
@@ -13,9 +13,9 @@ Those concerns remain in `docs/product-spec-context.md`, `docs/api-spec.md`, `do
 - Treat reviewed request content as immutable. Later changes must not silently overwrite that reviewed submission.
 - A request chain starts with one root request and may later gain employee-submitted follow-up requests.
 - A pending request may still be edited or withdrawn in place before admin review.
-- A reviewed outcome that asks the employee to act again must keep the prior review comment visible together with the next action.
+- A reviewed non-approved outcome must keep the prior review comment visible together with any downstream resubmission entry point that page-level IA exposes.
 - A chain may have at most one active employee-submitted follow-up at a time.
-- Employee and admin views must stay synchronized on the same active request, effective status, review rationale, and next action.
+- Employee and admin views must stay synchronized on the same active request, effective status, review rationale, and whether a linked follow-up now governs the chain.
 - The current product does not allow a manager to directly reverse an already approved request.
 - Approved-state follow-up `change` and `cancel` flows are currently formalized only for leave requests.
 - Manual attendance requests currently support pre-review edit and withdrawal plus post-review resubmission, but not approved-state follow-up `change` or `cancel`.
@@ -52,7 +52,6 @@ Root requests use `followUpKind = null`.
 ### Request Queue View
 
 - `needs_review`
-- `waiting_for_employee`
 - `completed`
 - `all`
 
@@ -61,7 +60,6 @@ These are derived queue groupings, not stored request statuses.
 ### Request Next Action
 
 - `admin_review`
-- `employee_resubmit`
 - `none`
 
 These values are shared request-surface projections, not attendance-display actions.
@@ -88,7 +86,9 @@ Do not add a separate `chainId` in the current product.
 
 `active*` points to the request that currently awaits employee or admin action and becomes `null` when a chain has no active work.
 `effective*` points to the request state that currently governs the chain, including pre-review `withdrawn`.
-`governingReviewComment` is the latest unresolved `reject` or `request_revision` rationale that must stay visible while the employee still owes a response; otherwise it is `null`.
+`governingReviewComment` is the latest unresolved `reject` or `request_revision` rationale that must stay visible while the latest non-approved reviewed outcome has not yet been resolved by a linked follow-up; otherwise it is `null`.
+When a chain is `rejected` or `revision_requested` with no active follow-up, `activeRequestId` and `activeStatus` are `null`, `effective*` still point to the latest reviewed outcome, and `nextAction = none`.
+Employee pages may still expose linked `resubmission` entry points from request status and relation fields, but that availability is not itself active work in the shared projection.
 
 ## Lifecycle Concepts
 
@@ -98,7 +98,7 @@ Do not add a separate `chainId` in the current product.
 | follow-up request | a later employee-submitted request linked to an earlier request            | used for resubmission, leave change, or leave cancel flows             |
 | active request    | the request that currently awaits action from either employee or admin     | there may be at most one active employee-submitted follow-up per chain |
 | effective status  | the request state that currently governs what the product should show      | may differ from latest activity while a follow-up is still pending     |
-| review comment    | the admin rationale attached to `reject` or `request_revision`             | must stay visible until the employee resolves that outcome             |
+| review comment    | the admin rationale attached to `reject` or `request_revision`             | must stay visible until a linked follow-up resolves that outcome       |
 | review event      | an append-only admin review record                                         | used for the first review on a request record                          |
 | supersession      | the relationship by which a newer approved follow-up replaces an older one | stored as request-to-request linkage, not as deleted history           |
 
@@ -110,7 +110,7 @@ Do not add a separate `chainId` in the current product.
 | Can a pending request be withdrawn directly?                 | Yes. Use `status = withdrawn` on the same request.                                                                                                      | Pre-review withdrawal is simpler than creating another lifecycle object.                                     |
 | How do employee clients mutate a pending request over HTTP?  | Use `PATCH /api/attendance/manual/[id]` or `PATCH /api/leave/request/[id]` to edit fields in place or set `status = withdrawn`.                         | The API contract must expose the same pre-review edit and withdraw behavior that the lifecycle model allows. |
 | Can a reviewed request be edited directly?                   | No.                                                                                                                                                     | Silent overwrite would break auditability and employee-admin trust.                                          |
-| How should an admin ask for corrections?                     | Use `status = revision_requested` through a `request_revision` review event.                                                                            | Both sides need one shared current state and next action.                                                    |
+| How should an admin ask for corrections?                     | Use `status = revision_requested` through a `request_revision` review event.                                                                            | Both sides need one shared reviewed outcome and rationale without reopening the same record.                 |
 | How should an employee reapply after a non-approved outcome? | Submit a prefilled follow-up request with `followUpKind = resubmission`.                                                                                | This preserves history while keeping resubmission easy.                                                      |
 | How should an employee modify an approved leave request?     | Submit a follow-up leave request with `followUpKind = change`.                                                                                          | The current approval must remain effective until the new request is reviewed.                                |
 | How should an employee cancel an approved leave request?     | Submit a follow-up leave request with `followUpKind = cancel`.                                                                                          | Pre-review withdrawal and post-approval cancellation are different contracts.                                |
@@ -141,11 +141,11 @@ Do not add a separate `chainId` in the current product.
 
 ### Admin Requests Revision Instead Of Rejecting Immediately
 
-| Moment                                                | Lifecycle Fact Changes                                                         | Effective Status                                                            | Required Surface Behavior                                                                                      |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| Admin reviews a pending request that needs correction | append a `request_revision` review event and set `status = revision_requested` | `effectiveStatus = revision_requested`; `nextAction = employee_resubmit`    | employee and admin both see the same current state, the same rationale, and the same next action               |
-| Employee opens the request detail                     | no new lifecycle change                                                        | revision request remains the governing state until a follow-up is submitted | the prior input, review comment, and correction path must appear together rather than in separate hidden views |
-| Admin checks the queue later                          | no new lifecycle change                                                        | the request is no longer untouched review work                              | the workspace must distinguish revision-requested items from untouched pending submissions                     |
+| Moment                                                | Lifecycle Fact Changes                                                         | Effective Status                                                                      | Required Surface Behavior                                                                                                                                                          |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Admin reviews a pending request that needs correction | append a `request_revision` review event and set `status = revision_requested` | `effectiveStatus = revision_requested`; `activeRequestId = null`; `nextAction = none` | employee and admin both see the same rationale and reviewed outcome, while employee pages may expose resubmission and admin pages stop treating the item as untouched pending work |
+| Employee opens the request detail                     | no new lifecycle change                                                        | revision request remains the governing state until a follow-up is submitted           | the prior input, review comment, and correction path must appear together rather than in separate hidden views                                                                     |
+| Admin checks the queue later                          | no new lifecycle change                                                        | the request is no longer untouched review work                                        | the workspace must distinguish revision-requested items from untouched pending submissions                                                                                         |
 
 ### Employee Resubmits After A Non-Approved Outcome
 
@@ -181,41 +181,41 @@ Do not add a separate `chainId` in the current product.
 
 ### Manager Encounters An Approved Request That Needs Adjustment
 
-| Moment                                                                       | Lifecycle Fact Changes                                                | Effective Status                                                       | Required Surface Behavior                                                                             |
-| ---------------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| A request is already approved, but the manager now believes it should change | no new lifecycle change in the current product                        | the existing approval remains effective                                | the product must not offer a direct `approved -> rejected` or manager-driven overwrite path           |
-| The manager needs an approved leave request to change                        | ask the employee to submit a follow-up leave change or cancel request | the earlier approval remains effective until the follow-up is reviewed | employee and admin should both understand that the next action belongs to the employee follow-up flow |
-| A true emergency override is discussed                                       | still no current-product lifecycle change                             | no exceptional admin override exists in the current scope              | treat this as future policy work tracked in issue `#53`, not as behavior to implement now             |
+| Moment                                                                       | Lifecycle Fact Changes                                                | Effective Status                                                       | Required Surface Behavior                                                                            |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| A request is already approved, but the manager now believes it should change | no new lifecycle change in the current product                        | the existing approval remains effective                                | the product must not offer a direct `approved -> rejected` or manager-driven overwrite path          |
+| The manager needs an approved leave request to change                        | ask the employee to submit a follow-up leave change or cancel request | the earlier approval remains effective until the follow-up is reviewed | employee and admin should both understand that follow-up responsibility belongs to the employee flow |
+| A true emergency override is discussed                                       | still no current-product lifecycle change                             | no exceptional admin override exists in the current scope              | treat this as future policy work tracked in issue `#53`, not as behavior to implement now            |
 
 ### Admin Tries To Re-Review A Non-Approved Request On The Same Record
 
-| Moment                                                                                              | Lifecycle Fact Changes                                              | Effective Status                                                                    | Required Surface Behavior                                                                                            |
-| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| Admin attempts to review a previously `rejected` or `revision_requested` request on the same record | no lifecycle change; reject the write with `409 conflict`           | the prior non-approved outcome remains governing until an employee follow-up exists | both sides must keep seeing the prior outcome, rationale, and `nextAction = employee_resubmit` as the current rule   |
-| The employee has not submitted a linked follow-up yet                                               | no new lifecycle change                                             | the non-approved reviewed step still governs the chain                              | the product must not look like the admin can reopen the same request record or silently change the earlier decision  |
-| The employee later submits a linked `resubmission` follow-up                                        | create a new follow-up request linked to the prior reviewed request | the new pending follow-up becomes the active and effective review target            | the old rationale remains visible as historical context, but the new pending follow-up becomes the only admin target |
+| Moment                                                                                              | Lifecycle Fact Changes                                              | Effective Status                                                                                     | Required Surface Behavior                                                                                                                                                                             |
+| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Admin attempts to review a previously `rejected` or `revision_requested` request on the same record | no lifecycle change; reject the write with `409 conflict`           | the prior non-approved outcome remains the latest reviewed result until an employee follow-up exists | both sides must keep seeing the prior outcome and rationale; employee pages may still expose resubmission from status and relation fields while admin pages keep the item as completed review history |
+| The employee has not submitted a linked follow-up yet                                               | no new lifecycle change                                             | the non-approved reviewed step still governs the chain                                               | the product must not look like the admin can reopen the same request record or silently change the earlier decision                                                                                   |
+| The employee later submits a linked `resubmission` follow-up                                        | create a new follow-up request linked to the prior reviewed request | the new pending follow-up becomes the active and effective review target                             | the old rationale remains visible as historical context, but the new pending follow-up becomes the only admin target                                                                                  |
 
 ### Latest Activity Versus Effective Status
 
-| Situation                                                               | Lifecycle Interpretation                                                                                                              | Required Surface Behavior                                                                                                          |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| A pending root request awaits first review                              | latest activity and effective status both point to the root pending request                                                           | show one pending item with `nextAction = admin_review`                                                                             |
-| A withdrawn root request has no follow-up                               | latest activity and effective status both point to the withdrawn request                                                              | keep it historical only; do not surface it as active work                                                                          |
-| A rejected or revision-requested request has no follow-up yet           | latest activity and effective status both point to the non-approved reviewed step                                                     | show the review comment and the submit-corrected-follow-up action together                                                         |
-| A rejected or revision-requested request has a new pending resubmission | latest activity and effective status both point to the resubmission, while the previous non-approved outcome remains relevant history | keep the previous review comment visible through linked chain history or parent-request context until the resubmission is reviewed |
-| An approved leave request has a pending change request                  | latest activity is the pending follow-up, but effective status is still the earlier approval                                          | show both facts together so the employee does not think the change is already approved                                             |
-| A follow-up approval supersedes an earlier approval                     | latest activity and effective status both point to the new approved follow-up                                                         | the older approval remains visible only as superseded history                                                                      |
+| Situation                                                               | Lifecycle Interpretation                                                                                                              | Required Surface Behavior                                                                                                                                                   |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A pending root request awaits first review                              | latest activity and effective status both point to the root pending request                                                           | show one pending item with `nextAction = admin_review`                                                                                                                      |
+| A withdrawn root request has no follow-up                               | latest activity and effective status both point to the withdrawn request                                                              | keep it historical only; do not surface it as active work                                                                                                                   |
+| A rejected or revision-requested request has no follow-up yet           | latest activity and effective status both point to the non-approved reviewed step, while active work is `null`                        | employee pages may show the review comment together with a resubmission entry point, while admin pages should show the reviewed outcome as completed review history/context |
+| A rejected or revision-requested request has a new pending resubmission | latest activity and effective status both point to the resubmission, while the previous non-approved outcome remains relevant history | keep the previous review comment visible through linked chain history or parent-request context until the resubmission is reviewed                                          |
+| An approved leave request has a pending change request                  | latest activity is the pending follow-up, but effective status is still the earlier approval                                          | show both facts together so the employee does not think the change is already approved                                                                                      |
+| A follow-up approval supersedes an earlier approval                     | latest activity and effective status both point to the new approved follow-up                                                         | the older approval remains visible only as superseded history                                                                                                               |
 
 ### Stale State Cleanup
 
-| Trigger                                                                 | Cleanup Expectation                                                                                                                       |
-| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| employee edits a pending request                                        | older pending payload snapshots disappear from active surfaces                                                                            |
-| employee withdraws a pending request                                    | pending queue badges and review CTAs clear immediately                                                                                    |
-| admin requests revision                                                 | simple pending indicators are replaced by revision-requested messaging and correction guidance                                            |
-| employee submits a resubmission                                         | old revision or rejection warnings stop being the active state and become historical context                                              |
-| admin approves a leave change or cancel follow-up                       | prior effective approvals become superseded history and stop driving active CTAs                                                          |
-| admin attempts a same-record rewrite of a reviewed non-approved request | no lifecycle change occurs; current banners, badges, queue states, and next actions remain unchanged while the API returns `409 conflict` |
+| Trigger                                                                 | Cleanup Expectation                                                                                                                                       |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| employee edits a pending request                                        | older pending payload snapshots disappear from active surfaces                                                                                            |
+| employee withdraws a pending request                                    | pending queue badges and review CTAs clear immediately                                                                                                    |
+| admin requests revision                                                 | simple pending indicators are replaced by revision-requested messaging and correction guidance                                                            |
+| employee submits a resubmission                                         | old revision or rejection warnings stop being the active state and become historical context                                                              |
+| admin approves a leave change or cancel follow-up                       | prior effective approvals become superseded history and stop driving active CTAs                                                                          |
+| admin attempts a same-record rewrite of a reviewed non-approved request | no lifecycle change occurs; current banners, badges, queue states, and history/context presentation remain unchanged while the API returns `409 conflict` |
 
 ## Shared Invariants And Forbidden Behaviors
 
@@ -223,7 +223,7 @@ Do not add a separate `chainId` in the current product.
 
 - A reviewed request must never be silently overwritten by a later employee change.
 - A reviewed `rejected` or `revision_requested` request stays locked to same-record admin review writes until an employee submits a linked `resubmission` follow-up.
-- Employee and admin views must agree on the same active request, effective status, review rationale, and next action for a chain.
+- Employee and admin views must agree on the same active request, effective status, review rationale, and whether a linked follow-up now governs the chain.
 - A resubmission, leave change request, or leave cancel request must stay visibly linked to the earlier request that it follows.
 - Resubmission flows must start from a prefilled copy of the earlier request rather than a blank form.
 - Pre-review withdrawal must remain distinguishable from post-approval cancellation.
@@ -241,7 +241,7 @@ Do not add a separate `chainId` in the current product.
 - Do not mark an approved leave request as changed or canceled before the follow-up request is actually reviewed and approved.
 - Do not let a manager directly reverse an already approved request in the current product.
 - Do not allow the same chain to accumulate multiple active employee-submitted follow-up requests at once.
-- Do not let employee and admin screens disagree about whether a request is pending review, awaiting employee correction, still effectively approved, or already superseded.
+- Do not let employee and admin screens disagree about whether a request is pending review, completed reviewed history that is still eligible for linked resubmission, still effectively approved, or already superseded.
 
 ## Downstream Ownership And Follow-Up
 

--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -71,6 +71,11 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 - Every important state should communicate the current state, the reason, and the next action.
 - Warnings should explain why the user is seeing them now, not only what label applies.
 - Use state-specific surfaces for state-specific follow-up. For example, a failed attendance attempt should offer a correction path, while a pending request should offer status visibility rather than a duplicate submission path.
+- On `/admin/attendance/requests`, treat reviewed `rejected` and `revision_requested` items as completed review history/context inside `completed` and `all`, not as a separate employee-waiting queue.
+- Give reviewed non-approved history lower visual emphasis than actionable `needs_review` work.
+- Do not frame reviewed non-approved admin rows or detail surfaces as "waiting for employee".
+- Do not show employee-resubmit CTA copy or guidance inside admin detail for those reviewed-history cases.
+- Keep their rationale visible without implying new admin action on the same record.
 - Lead with known facts rather than speculative questions when the product already knows what is wrong. Put any follow-up user-judgment question inside the next step only when the product genuinely needs that judgment.
 - When `/admin/attendance` shows manual-request context inside a row, keep it as a compact derived projection rather than a full request detail surface. If the projection points at a prior-workday correction, show the target date explicitly.
 - After an approval, rejection, resubmission, or successful correction, stale warnings, badges, and CTAs must be replaced or cleared promptly.


### PR DESCRIPTION
﻿Closes #64

This is a docs-only and issue-alignment PR that promotes the decision to remove `waiting_for_employee` as a shared product/admin queue concept.

## Summary
This PR turns the new `#64` direction into canonical docs language across the request lifecycle, API, schema, product context, and admin workspace guidance.

Reviewed `rejected` and `revision_requested` requests with no active follow-up are now documented as:
- admin-side completed review history
- not active admin queue work
- not a shared employee-waiting queue state

Employee resubmission remains allowed, but it is now documented as page-level IA rather than shared request-projection semantics.

## What Changed
### Shared request vocabulary
- Removed `waiting_for_employee` from `Request Queue View`.
- Removed shared `employee_resubmit` from `Request Next Action`.
- Normalized the canonical queue/view contract to `needs_review | completed | all`.
- Normalized the canonical next-action contract to `admin_review | none`.

### Reviewed non-approved no-follow-up projection
- Documented that for reviewed `rejected` / `revision_requested` requests with no active follow-up:
  - `activeRequestId = null`
  - `activeStatus = null`
  - `effectiveRequestId` / `effectiveStatus` still point to the latest reviewed outcome
  - `nextAction = none`
- Clarified that employee resubmission entry points may still be derived from request status and relation fields.
- Clarified that this availability is not shared active work.

### Admin request workspace contract
- Documented `/admin/attendance/requests` with `needs_review`, `completed`, and `all` only.
- Documented that reviewed non-approved items appear in `completed` and `all` only, never in `needs_review`.
- Documented that those items are completed review history/context on admin surfaces.
- Documented that admin-side next action for those rows is effectively no further admin action on the same record.

### UI and product-language guidance
- Added UI guidance that reviewed non-approved admin items should have lower emphasis than actionable review work.
- Prohibited “waiting for employee” framing on admin surfaces.
- Prohibited employee-resubmit CTA/guidance inside admin detail for those completed-history cases.
- Clarified that rationale must remain visible without implying same-record admin action.

### Rationale and historical cleanup
- Updated product-spec context so any remaining `waiting_for_employee` mention is explicitly historical or rejected-alternative vocabulary only.
- Preserved the rationale for removing the queue concept without creating a new source-of-truth document.

## Decision Record
This PR promotes these final decisions:
- `waiting_for_employee` is no longer an active source-of-truth queue concept.
- Reviewed non-approved requests do not count as shared active work when no linked follow-up exists.
- Employee resubmission remains valid, but is owned by employee page IA rather than shared queue-state semantics.
- Admin request review surfaces treat these rows as completed review history, not pending work and not same-record rewritable items.

## Discussion / Why
The old framing mixed two different concerns:
- request-chain lifecycle truth
- admin workspace placement of reviewed non-approved items

The repo had already settled same-record lock behavior in `#65` / `PR #67`.
The remaining work was documentation cleanup and vocabulary convergence.
Keeping `waiting_for_employee` in shared docs risked reintroducing the old semantics in later implementation issues.
This rewrite simplifies the admin queue contract while preserving employee resubmission behavior.

## Cross-Doc Audit
This PR checked and aligned:
- queue-view vocabulary across lifecycle, API, and schema docs
- next-action vocabulary across lifecycle, API, and schema docs
- admin request workspace requirements and UI rules
- product-spec context and rejected alternatives

`docs/api-spec.md`, `docs/database-schema.md`, and `docs/request-lifecycle-model.md` now tell the same story for reviewed non-approved no-follow-up chains.

## Validation
- `git diff --check` is clean.
- Repo-wide grep shows `employee_resubmit` removed from canonical docs.
- Repo-wide grep shows `waiting_for_employee` remains only in `docs/product-spec-context.md` as historical/rejected-alternative context.
- `pnpm lint` passed.
- `pnpm format:check` passed.
- The pre-push hook also ran `pnpm build` and `pnpm test`, and both passed.

## Out of Scope
- No `lib/**` or `lib/contracts/**` edits.
- No `app/**`, `components/**`, Route Handler, or mock data changes.
- No runtime/API implementation changes.
- No new source-of-truth document.

## Follow-Ups
- `#41` continues to own employee leave-page IA.
- `#42` continues to own admin review workspace IA.
- `#66` continues to own employee-side suppression behavior.
- `#41` still has a `calendar-first` title while the body now describes a hybrid IA. That is a non-blocking metadata cleanup for later.
