### PR TITLE
docs: finalize leave page IA contract

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -542,7 +542,7 @@ Response notes:
 - follow-up `resubmission`, `change`, and `cancel` requests remain linked to the earlier request rather than silently replacing it
 - each leave request item in this `GET /api/leave/me` employee aggregate also includes `isTopSurfaceSuppressed`, an employee-specific derived flag for `/attendance/leave` top correction auto-surfacing only
 - `isTopSurfaceSuppressed` is not a guaranteed field on every leave-request response shape; it is part of this employee aggregate response because this endpoint backs the leave page's history plus top-correction projection
-- when `isTopSurfaceSuppressed = true`, the reviewed request remains available in history and request-context surfaces but is excluded from top correction auto-surfacing until restored
+- when `isTopSurfaceSuppressed = true`, the reviewed request remains available in history and date-relevant selected-date context surfaces but is excluded from top correction auto-surfacing until restored
 - top-surface suppression persists across sessions and browser instances for the owning employee account
 - admin request endpoints do not expose `isTopSurfaceSuppressed`
 

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -73,20 +73,22 @@ Required UI:
 - a stable top summary tier that always shows leave balance plus calm current-state context rather than escalating plain pending requests into the top correction surface
 - a conditional top correction tier for reviewed non-approved leave requests that still need employee attention without treating them as a shared queue state
 - a leave-only planning calendar with selected-date context directly below it
-- one inline leave composer below the calendar that owns new leave request, `resubmission`, approved-state `change`, and approved-state `cancel` flows
+- one inline leave composer below the calendar that supports annual leave, half-day AM, half-day PM, and hourly leave and owns new leave request, `resubmission`, approved-state `change`, and approved-state `cancel` flows
 - a flat list of the current user's leave request chains, ordered by latest activity, with each row representing the current governing chain context rather than every request record as a separate top-level row
+- each leave-chain history row should summarize the governed date or date range, leave type, employee reason summary, current governing status, and latest review timing while earlier chain steps remain secondary chain detail rather than separate top-level rows
 - visible prior review comments and follow-up context when a leave request is `revision_requested` or `rejected`
 - reviewed non-approved leave requests should read as completed admin review with a clear employee-side resubmission path; `revision_requested` should emphasize correction guidance, while `rejected` should emphasize refusal of the current version without removing the linked resubmission path
 - a prefilled follow-up path for leave `resubmission`, approved-state `change`, and approved-state `cancel` flows
 - when multiple reviewed non-approved leave requests qualify for top correction surfacing, a compact candidate list plus one expanded detail that defaults to the most recently reviewed eligible request
 - top correction detail that keeps the prior request summary, reviewed outcome, review reason, next action, primary `resubmit`, and the hide/show-top affordance together
 - reviewed non-approved leave requests may be hidden from top correction auto-surfacing one reviewed request at a time without removing history, rationale, or linked resubmission context
-- history must remain the required recovery surface for a previously suppressed reviewed leave request, while request-context or selected-date context may add optional restore or resubmission entry points without replacing history
-- employees may restore a previously suppressed reviewed leave request from history or request-context surfaces when they want it back in the top correction tier
+- history must remain the required recovery surface for a previously suppressed reviewed leave request, while the top correction detail or selected-date context may add optional restore or resubmission entry points without replacing history
+- employees may restore a previously suppressed reviewed leave request from history or selected-date context surfaces when they want it back in the top correction tier
 - suppressing one reviewed leave request must not hide a different request that only shares the same date, leave type, or root chain history
 - selecting a date with existing leave context must show the governing chain context before offering a blank new-request flow
 - if a clicked date belongs to a multi-day leave range, the selected-date context must show the governing full range rather than only the clicked date
 - selected-date context should lead with one governing chain card and keep other date-related items as compact secondary links rather than a stack of equal full cards
+- top-correction and history CTAs should converge on the same inline composer so the write-flow owner stays unambiguous across new request, `resubmit`, `change`, and `cancel`
 - pending leave actions should stay history-led with `edit` primary and `withdraw` secondary; approved leave actions should stay history-led with `change` primary and `cancel` secondary
 - suppressed reviewed non-approved rows should keep `resubmit` as the primary action and may add `show again at top` as a secondary recovery action where relevant
 - approved leave with a pending `change` or `cancel` follow-up must show both the current effective approval and the pending follow-up context together so the employee does not misread the follow-up as already effective

--- a/docs/request-lifecycle-model.md
+++ b/docs/request-lifecycle-model.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 This document is the primary source of truth for request workflow semantics across manual attendance requests and leave requests.
-It explains when a request may be edited, withdrawn, revised, resubmitted, changed, canceled, or decision-revised, and which cross-screen guarantees must hold for both employee and admin views.
+It explains when a request may be edited, withdrawn, revised, resubmitted, changed, or canceled, and which cross-screen guarantees must hold for both employee and admin views.
 
 This document does not own raw discussion history, full HTTP payload definitions, or final UI layout decisions.
 Those concerns remain in `docs/product-spec-context.md`, `docs/api-spec.md`, `docs/database-schema.md`, `docs/feature-requirements.md`, and `docs/ui-guidelines.md`.

--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -99,7 +99,7 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 - Keep selected-date context visible in every queue view, but reduce its visual emphasis in `completed` so historical annotations read as context rather than current pressure.
 - Use dim or outlined historical calendar marks for completed-history items rather than the same style used for active review pressure.
 - On `/attendance/leave`, the top correction tier should filter candidates to reviewed `rejected` or `revision_requested` leave requests with no active follow-up and `isTopSurfaceSuppressed = false`.
-- Treat leave top-surface suppression as a candidate filter only. History must remain the required recovery surface, and request-context or selected-date context may add restore or resubmission entry points without replacing history.
+- Treat leave top-surface suppression as a candidate filter only. History must remain the required recovery surface, and the top correction detail or selected-date context may add restore or resubmission entry points without replacing history.
 - A later resubmission or later reviewed outcome must be re-evaluated as a new top-correction candidate rather than inheriting an older request record's suppressed state.
 - Let issue `#66` own top-candidate filtering and persistence; keep ordering, default expansion, placement, and CTA hierarchy with issue `#41`.
 - On `/attendance/leave`, keep one stable top summary tier visible even when correction candidates exist. That tier should stay calm, lead with leave balance, and summarize the current leave state without pulling plain `pending` requests into the top correction surface.
@@ -110,7 +110,7 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 - `pending` leave rows should lead with `edit` and offer `withdraw` as the secondary action. `approved` leave rows should lead with `change` and offer `cancel`. `rejected` or `revision_requested` rows should lead with `resubmit`, while suppressed reviewed rows may add `show again at top` as a secondary recovery action.
 - `withdrawn` rows and fully superseded historical approvals should stay read-only in the history list and should not advertise fresh action CTAs.
 - Use the calendar on `/attendance/leave` as leave-only planning and context, not as a shared attendance correction launcher.
-- Keep one selected-date context area directly below the calendar. If the selected date already belongs to leave-request context, show that governing context before showing a blank new-request flow.
+- Keep one selected-date context area directly below the calendar. If the selected date already belongs to an existing leave request chain, show that governing context before showing a blank new-request flow.
 - Selected-date context on `/attendance/leave` should be governing-context-first: show one primary governing chain card, and keep additional date-related items as compact secondary links rather than a stack of equal cards.
 - If the clicked date falls inside a multi-day leave request, show the governing full leave range in the primary context card rather than reducing it to the clicked day alone.
 - Keep one inline composer below the calendar as the only primary owner of new request, `resubmit`, `change`, and `cancel` flows on `/attendance/leave`.


### PR DESCRIPTION
Closes #41

## Summary

This is a docs-only PR that promotes the final `/attendance/leave` page-local information architecture into the repository's canonical docs.

The upstream shared contracts are already fixed by earlier work:

- `#64` / PR `#68` removed `waiting_for_employee` as a shared queue concept
- `#65` / PR `#67` locked same-record non-approved request rewrites out of scope
- `#66` / PR `#70` finalized persistent employee-side top-surface suppression semantics

This PR does not reopen any of those shared contracts.
Instead, it finishes the remaining responsibility of `#41`: define the employee leave-page IA on top of those fixed inputs.

## Issue Context

Issue `#41` started as a broader discussion about employee leave-page planning, visible request history, resubmission entry, and approved-state change/cancel flows.

As upstream contract work landed, the issue narrowed into one route-local problem:

- what the top of `/attendance/leave` should show
- which leave requests should surface as top correction context
- whether history should be request-record-first or chain-first
- how selected-date context should relate to the calendar
- where new request, `resubmit`, `change`, and `cancel` flows should actually open
- how suppressed reviewed items should stay recoverable without being treated as shared active work

The final direction promoted by this PR is:

- stable top summary tier
- conditional top correction tier
- leave-only calendar
- governing-context-first selected-date context
- one inline composer below the calendar
- flat chain-first history

## Final Decisions Promoted

This PR promotes the following final `#41` decisions into canonical docs:

- `/attendance/leave` uses a hybrid layout rather than a pure calendar-first or pure history-first layout.
- The stable top summary tier always stays visible and shows leave balance plus calm current-state context.
- Plain `pending` requests do not escalate into the top correction tier.
- The top correction tier is limited to reviewed `rejected` / `revision_requested` leave requests with no active follow-up and `isTopSurfaceSuppressed = false`.
- When multiple reviewed non-approved candidates exist, the top correction surface uses a compact list plus one expanded detail, defaulting to the most recently reviewed candidate.
- The expanded top-correction detail keeps prior request summary, reviewed outcome, review reason, next action, primary `resubmit`, and hide/show-top affordance together.
- History is chain-first, not record-first.
- History rows are ordered by latest activity descending.
- Each history row summarizes the governed date or date range, leave type, employee reason summary, current governing status, and latest review timing.
- Earlier chain steps may remain visible as secondary chain detail, but do not become separate top-level rows by default.
- History CTA hierarchy is fixed:
  - `pending`: `edit` primary, `withdraw` secondary
  - `rejected` / `revision_requested`: `resubmit` primary
  - suppressed reviewed non-approved rows: `resubmit` primary, `show again at top` secondary where relevant
  - `approved`: `change` primary, `cancel` secondary
  - `withdrawn` and fully superseded approvals: read-only
- Approved leave with a pending `change` or `cancel` follow-up must display as explicit dual-state:
  - current effective approval first
  - pending follow-up second as requested-but-not-effective-yet context
- The calendar is leave-only planning/context, not a shared attendance correction launcher.
- Clicking a date updates selected-date context below the calendar.
- Selected-date context is governing-context-first:
  - if the date belongs to an existing leave chain, that governing context wins over a blank new-request flow
  - if the date falls inside a multi-day leave range, the primary card shows the full governed range
  - if multiple related items exist for the same date, show one primary governing card plus compact secondary links instead of a full stack of equal cards
- All write flows converge on one inline composer below the calendar.
- New request, `resubmit`, `change`, and `cancel` do not open separate modal/sheet owners.
- Top-correction and history CTAs sync date/range, update selected-date context, and open the same inline composer with the proper prefilled flow.
- New request flow starts from the selected date, while final date-range and leave-type refinement stays inside the composer.
- `pending` edit/withdraw and approved-state `change`/`cancel` remain history-led actions.
- `resubmit` is top-correction-led when an eligible reviewed item is currently surfaced there.
- Suppressed reviewed items never count as top-correction candidates, but remain recoverable from history and date-relevant selected-date context.
- Conflict warnings remain intentionally duplicated:
  - first on calendar date surfaces
  - again inside the inline composer before submission

## Documentation Changes

### `docs/feature-requirements.md`

This PR rewrites the leave-management requirements from a generic form/history description into the final route-level IA contract.

It now explicitly records:

- stable summary tier
- conditional top correction tier
- leave-only calendar plus selected-date context
- one inline composer as the single write-flow owner
- chain-first history
- history row content expectations
- supported leave input scope:
  - annual leave
  - half-day AM
  - half-day PM
  - hourly leave
- unified CTA ownership across top correction and history
- multi-day selected-date behavior
- suppressed-item recovery behavior
- dual-state approved-plus-follow-up display

### `docs/ui-guidelines.md`

This PR adds the implementation-facing IA rules for `/attendance/leave`, including:

- stable summary placement above correction and planning surfaces
- top correction placement directly below the summary tier
- compact-list-plus-expanded-detail behavior for multiple reviewed candidates
- chain-first history behavior and row CTA hierarchy
- governing-context-first selected-date behavior
- single inline composer ownership
- no modal/sheet split for leave write flows
- history-led versus top-correction-led action discovery
- approved follow-up dual-state presentation

It also removes ambiguous `request-context` wording and replaces it with explicit named surfaces such as `top correction detail` and `selected-date context`.

### `docs/request-lifecycle-model.md`

This PR removes stale wording that still suggested the lifecycle doc explains “decision-revised” behavior.
That wording became wrong after `#65` / PR `#67` locked same-record non-approved review rewrites out of scope.

No actual lifecycle contract is changed in this PR.

### `docs/api-spec.md`

This PR keeps the suppression endpoint contract unchanged, but aligns leave-page recovery wording with the finalized IA vocabulary.

It now describes suppressed reviewed items as remaining available in:

- history
- date-relevant selected-date context surfaces

instead of the older ambiguous `request-context` phrasing.

## GitHub Issue Alignment

In addition to the git diff, `#41` itself was tightened on GitHub to match the final contract:

- the issue body now carries the final `/attendance/leave` IA at full decision level
- a stale comment that incorrectly said `nextAction = employee_resubmit` was corrected to match the promoted shared contract (`nextAction = none` when no active follow-up exists)
- an older corrupted historical comment was rewritten into a readable historical note and explicitly marked as superseded where later decisions changed the contract

These issue updates are intentionally part of the narrative for this PR even though they are not visible in the repository diff.

## Consistency Review

This PR also performs a document-level consistency pass.

After the changes:

- canonical docs no longer use stale `employee_resubmit` vocabulary
- canonical docs no longer use stale `decision-revised` wording
- ambiguous `request-context` wording is removed from the leave-page contract path
- `docs/request-lifecycle-model.md`, `docs/api-spec.md`, and `docs/database-schema.md` still agree that reviewed non-approved requests with no active follow-up have `nextAction = none`
- remaining `waiting_for_employee` mentions are confined to `docs/product-spec-context.md` as explicitly historical/rejected-alternative context only

## Out of Scope

This PR does not:

- change runtime code
- implement `/attendance/leave`
- change API routes or payload shapes
- change schema entities or enums
- reopen shared request lifecycle semantics
- reopen shared queue semantics
- reopen suppression persistence or endpoint semantics

## Validation

This is a docs-only PR.

Validation performed for the branch should focus on contract consistency:

- `git diff --check`
- grep for stale contract vocabulary
- cross-doc review of:
  - `docs/feature-requirements.md`
  - `docs/ui-guidelines.md`
  - `docs/request-lifecycle-model.md`
  - `docs/api-spec.md`
- confirmation that `#41` remains open and will close through merge via `Closes #41`

No automated tests are required for this PR because it changes documentation and GitHub issue metadata only.
