### PR TITLE
fix: address post-merge codex review feedback for attendance derivation

### DIFF
--- a/lib/attendance/derivation.ts
+++ b/lib/attendance/derivation.ts
@@ -5,6 +5,7 @@ import type {
   AttendanceFlag,
   AttendancePhase,
   AttendanceRecord,
+  AttendanceSurfaceManualRequestResource,
   ExpectedWorkday,
   PreviousDayOpenRecord,
 } from "@/lib/contracts/shared";
@@ -15,6 +16,7 @@ type DeriveAttendanceDisplayInput = {
   record: AttendanceRecord | null;
   attempts: AttendanceAttempt[];
   previousDayOpenRecord: PreviousDayOpenRecord | null;
+  manualRequest?: AttendanceSurfaceManualRequestResource | null;
 };
 
 type DeriveAdminAttendanceSummaryItem = {
@@ -194,6 +196,7 @@ function deriveActiveExceptions({
   record,
   attempts,
   previousDayOpenRecord,
+  manualRequest,
   phase,
 }: DeriveAttendanceDisplayInput & {
   phase: AttendancePhase;
@@ -246,6 +249,14 @@ function deriveActiveExceptions({
 
   if (latestOperationalFailure) {
     activeExceptions.push("attempt_failed");
+  }
+
+  if (manualRequest?.effectiveStatus === "pending") {
+    activeExceptions.push("manual_request_pending");
+  }
+
+  if (manualRequest?.effectiveStatus === "rejected") {
+    activeExceptions.push("manual_request_rejected");
   }
 
   if (

--- a/lib/contracts/shared.ts
+++ b/lib/contracts/shared.ts
@@ -260,6 +260,15 @@ function validateRequestChainProjection(
     });
   }
 
+  if (!hasActiveRequest && value.effectiveStatus === "pending") {
+    ctx.addIssue({
+      code: "custom",
+      path: ["effectiveStatus"],
+      message:
+        'Invalid input: "effectiveStatus" cannot be "pending" when no active work exists',
+    });
+  }
+
   if (hasActiveRequest && value.nextAction !== "admin_review") {
     ctx.addIssue({
       code: "custom",

--- a/tests/unit/api-contracts.test.ts
+++ b/tests/unit/api-contracts.test.ts
@@ -302,6 +302,20 @@ describe("shared contract schemas", () => {
       }),
     ).toThrow();
   });
+
+  it("rejects pending effective status when no active request exists", () => {
+    expect(() =>
+      requestChainProjectionSchema.parse({
+        activeRequestId: null,
+        activeStatus: null,
+        effectiveRequestId: "req_manual_001",
+        effectiveStatus: "pending",
+        governingReviewComment: null,
+        hasActiveFollowUp: false,
+        nextAction: "none",
+      }),
+    ).toThrow();
+  });
 });
 
 describe("employee attendance contracts", () => {

--- a/tests/unit/attendance-derivation.test.ts
+++ b/tests/unit/attendance-derivation.test.ts
@@ -8,6 +8,7 @@ import type {
   AttendanceAttempt,
   AttendanceDisplay,
   AttendanceRecord,
+  AttendanceSurfaceManualRequestResource,
   ExpectedWorkday,
   PreviousDayOpenRecord,
 } from "@/lib/contracts/shared";
@@ -64,6 +65,34 @@ function createPreviousDayOpenRecord(
     clockInAt: "2026-03-29T09:00:00+09:00",
     clockOutAt: null,
     expectedClockOutAt: "2026-03-29T18:00:00+09:00",
+    ...overrides,
+  };
+}
+
+function createManualRequest(
+  overrides: Partial<AttendanceSurfaceManualRequestResource> = {},
+): AttendanceSurfaceManualRequestResource {
+  return {
+    id: "req_manual_001",
+    requestType: "manual_attendance",
+    action: "clock_in",
+    date: "2026-03-30",
+    requestedAt: "2026-03-30T09:15:00+09:00",
+    reason: "Beacon retry failed",
+    status: "pending",
+    reviewedAt: null,
+    reviewComment: null,
+    rootRequestId: "req_manual_001",
+    parentRequestId: null,
+    followUpKind: null,
+    supersededByRequestId: null,
+    activeRequestId: "req_manual_001",
+    activeStatus: "pending",
+    effectiveRequestId: "req_manual_001",
+    effectiveStatus: "pending",
+    governingReviewComment: null,
+    hasActiveFollowUp: false,
+    nextAction: "admin_review",
     ...overrides,
   };
 }
@@ -280,6 +309,59 @@ describe("attendance derivation", () => {
       activeExceptions: ["previous_day_checkout_missing", "not_checked_in"],
       nextAction: {
         type: "resolve_previous_day_checkout",
+        relatedRequestId: null,
+      },
+    });
+  });
+
+  it("surfaces pending manual requests in attendance exceptions", () => {
+    expect(
+      deriveAttendanceDisplay({
+        now: "2026-03-30T09:20:00+09:00",
+        expectedWorkday: createExpectedWorkday(),
+        record: null,
+        attempts: [],
+        previousDayOpenRecord: null,
+        manualRequest: createManualRequest(),
+      }),
+    ).toEqual({
+      phase: "before_check_in",
+      flags: [],
+      activeExceptions: ["manual_request_pending", "not_checked_in"],
+      nextAction: {
+        type: "review_request_status",
+        relatedRequestId: null,
+      },
+    });
+  });
+
+  it("surfaces rejected manual requests in attendance exceptions", () => {
+    expect(
+      deriveAttendanceDisplay({
+        now: "2026-03-30T18:05:00+09:00",
+        expectedWorkday: createExpectedWorkday(),
+        record: null,
+        attempts: [],
+        previousDayOpenRecord: null,
+        manualRequest: createManualRequest({
+          id: "req_manual_002",
+          status: "rejected",
+          reviewedAt: "2026-03-30T17:30:00+09:00",
+          reviewComment: "Need clearer retry context.",
+          activeRequestId: null,
+          activeStatus: null,
+          effectiveRequestId: "req_manual_002",
+          effectiveStatus: "rejected",
+          governingReviewComment: "Need clearer retry context.",
+          nextAction: "none",
+        }),
+      }),
+    ).toEqual({
+      phase: "before_check_in",
+      flags: [],
+      activeExceptions: ["manual_request_rejected", "absent"],
+      nextAction: {
+        type: "review_request_status",
         relatedRequestId: null,
       },
     });


### PR DESCRIPTION
## Summary

This is a post-merge follow-up to #74 for issue #20.

PR #74 landed the shared attendance day-state derivation foundation, but it was merged before Codex finished its review cycle. After the merge, two unresolved Codex findings remained open on the merged PR. This PR addresses only those remaining gaps and keeps the scope narrow: one attendance derivation correction and one shared contract invariant correction.

## Context

Issue #20 intentionally narrowed the attendance foundation work to shared day-state derivation only. The canonical scope, both in the issue body and in the source-of-truth docs, is:

- employee and admin attendance surfaces must derive the same date-level display state from the same facts
- attendance display state is split into `phase`, `flags`, `activeExceptions`, and `nextAction`
- approved leave shifts the expected work window used for lateness and absence checks
- `not_checked_in` is real-time only, while `absent` is day-close/finalized only
- failed attempts remain exceptions, not attendance phase/status
- previous-day open checkout remains visible through carry-over handling
- manual request state can affect attendance display when it is still operationally relevant

PR #74 implemented the main derivation module and the contract realignment, but Codex found two remaining mismatches between the code and the documented attendance/request model.

## What Was Still Wrong After #74

### 1. Manual request state was not actually part of attendance display derivation

The derivation layer already knew how to map `manual_request_pending` and `manual_request_rejected` to `review_request_status` in `deriveNextAction(...)`, but `deriveAttendanceDisplay(...)` did not accept any manual-request input.

That meant the derivation layer could never actually emit those exceptions, even when the embedded attendance `manualRequest` surface clearly showed that a pending or rejected manual attendance request still mattered for the current workday.

In practice, the wrong behavior was:

- pending manual request days still derived `clock_in`
- rejected manual request days still derived `submit_manual_request`
- employee/admin display logic could drift away from the source-of-truth attendance model even though the shared exception vocabulary already existed

This contradicted:

- `docs/attendance-operating-model.md`
- `docs/api-spec.md`
- `docs/database-schema.md`

Those docs explicitly allow attendance surfaces to expose `manual_request_pending` and `manual_request_rejected` when the embedded manual request is still relevant to the current attendance state.

### 2. Request-chain projections still allowed an internally contradictory pending state

`validateRequestChainProjection(...)` already enforced that:

- active request id and active status must be paired
- active request status must be `pending`
- `nextAction` must be `admin_review` when active work exists
- `nextAction` must be `none` when no active work exists

But it still allowed:

- `activeRequestId = null`
- `activeStatus = null`
- `effectiveStatus = pending`
- `nextAction = none`

That shape is contradictory under the request lifecycle model. If the chain is effectively pending, there must still be active pending work. The docs explicitly reserve the no-active state for reviewed or withdrawn outcomes such as `rejected`, `revision_requested`, `approved`, or `withdrawn`.

## Changes In This PR

### Attendance derivation

Updated `lib/attendance/derivation.ts` so the shared derivation layer can now consume the embedded attendance manual-request surface.

Specifically:

- added `manualRequest` to the derivation input shape
- derive `manual_request_pending` when the embedded manual request has `effectiveStatus = pending`
- derive `manual_request_rejected` when the embedded manual request has `effectiveStatus = rejected`
- preserve the existing next-action priority so those exceptions now correctly route to `review_request_status`
- keep the rest of the attendance foundation unchanged

This keeps the derivation attendance-focused. It does not introduce request-lifecycle behavior beyond surfacing the already-documented attendance exceptions.

### Shared request-chain contract invariant

Updated `lib/contracts/shared.ts` so request-chain projections now reject `effectiveStatus = pending` when no active request exists.

This closes the gap between the runtime contract and the documented lifecycle semantics and prevents impossible embedded request summaries from being treated as valid contract output.

## Tests Added

Added regression coverage for both findings.

### `tests/unit/attendance-derivation.test.ts`

Added explicit red/green coverage for:

- pending manual attendance request on a same-day missing-check-in surface
- rejected manual attendance request on a finalized-absence surface

These tests verify that the shared derivation now emits:

- the correct `activeExceptions`
- the correct `review_request_status` next action

### `tests/unit/api-contracts.test.ts`

Added a contract regression test that rejects request-chain projections where:

- there is no active request
- but `effectiveStatus` is still `pending`

## Out Of Scope

This PR does not reopen or expand the scope of #20.

It does not add:

- route handler changes
- page/UI changes
- request-lifecycle workflow implementation
- new docs vocabulary
- new attendance statuses

The goal here is only to finish the shared foundation work that #74 intended to land and to remove the two remaining mismatches flagged by Codex after the merge.

## Validation

Ran and passed:

- `pnpm test:unit -- tests/unit/attendance-derivation.test.ts`
- `pnpm test:unit -- tests/unit/api-contracts.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## References

- Fixes the remaining post-merge Codex findings left on #74
- Continues issue #20
- Keeps the attendance foundation aligned with the contracts documented in:
  - `docs/attendance-operating-model.md`
  - `docs/request-lifecycle-model.md`
  - `docs/api-spec.md`
  - `docs/database-schema.md`
