### PR TITLE
leave: lock validation contract

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -560,6 +560,7 @@ Response notes:
 - approved leave may later surface in attendance endpoints as `leaveCoverage`
 - a later attendance fact on an approved leave-covered day should surface as a leave-work conflict in attendance APIs rather than silently rewriting the leave request
 - follow-up `resubmission`, `change`, and `cancel` requests remain linked to the earlier request rather than silently replacing it
+- hourly leave request items expose `startAt` and `endAt` as the authoritative interval fields, with `hours` derived for display/output only
 - each leave request item in this `GET /api/leave/me` employee aggregate also includes `isTopSurfaceSuppressed`, an employee-specific derived flag for `/attendance/leave` top correction auto-surfacing only
 - `isTopSurfaceSuppressed` is not a guaranteed field on every leave-request response shape; it is part of this employee aggregate response because this endpoint backs the leave page's history plus top-correction projection
 - when `isTopSurfaceSuppressed = true`, the reviewed request remains available in history and date-relevant selected-date context surfaces but is excluded from top correction auto-surfacing until restored
@@ -581,6 +582,8 @@ Response:
       "requestType": "leave",
       "leaveType": "hourly",
       "date": "2026-04-03",
+      "startAt": "2026-04-03T13:00:00+09:00",
+      "endAt": "2026-04-03T15:00:00+09:00",
       "hours": 2,
       "reason": "Personal appointment moved later.",
       "status": "pending",
@@ -612,7 +615,8 @@ Request body:
 
 - `leaveType`: required
 - `date`: required
-- `hours`: required only when `leaveType` is `hourly`
+- `startAt`: required only when `leaveType` is `hourly`
+- `endAt`: required only when `leaveType` is `hourly`
 - `reason`: required employee note
 - `parentRequestId`: optional; required for follow-up submissions
 - `followUpKind`: optional `resubmission`, `change`, or `cancel`
@@ -620,9 +624,12 @@ Request body:
 Current-scope rules:
 
 - Omit `parentRequestId` and `followUpKind` for a new root leave request.
+- `date` may target only today or a future workday in the first pass.
 - `followUpKind = resubmission` is valid only when the parent request currently has `status = rejected` or `revision_requested`.
 - `followUpKind = resubmission` creates a new pending follow-up and does not reopen the parent reviewed request in place.
 - `followUpKind = change` or `cancel` is valid only when the parent request itself currently has `status = approved` and `supersededByRequestId = null`.
+- Hourly leave uses explicit `startAt` and `endAt` interval fields. `hours` is derived output data and is not accepted as write input.
+- Duplicate prevention is overlap-based, not type-label-based: the same employee cannot create a second unsuperseded root leave chain whose effective leave interval overlaps another unsuperseded root chain.
 - A chain may have at most one active employee-submitted follow-up at a time.
 
 Request body:
@@ -631,7 +638,8 @@ Request body:
 {
   "leaveType": "hourly",
   "date": "2026-04-03",
-  "hours": 2,
+  "startAt": "2026-04-03T13:00:00+09:00",
+  "endAt": "2026-04-03T15:00:00+09:00",
   "reason": "Medical appointment moved later.",
   "parentRequestId": "req_leave_001",
   "followUpKind": "change"
@@ -646,6 +654,8 @@ Response:
   "requestType": "leave",
   "leaveType": "hourly",
   "date": "2026-04-03",
+  "startAt": "2026-04-03T13:00:00+09:00",
+  "endAt": "2026-04-03T15:00:00+09:00",
   "hours": 2,
   "reason": "Medical appointment moved later.",
   "status": "pending",
@@ -668,8 +678,8 @@ Response:
 
 Typical error cases:
 
-- `400 validation_error` for invalid dates or missing required fields
-- `409 conflict` when a conflicting leave request already exists
+- `400 validation_error` for invalid dates, missing required fields, or invalid hourly intervals
+- `409 conflict` when an overlapping leave request already exists for the same employee
 - `409 conflict` when the same chain already has another active employee follow-up; include the existing active follow-up request id in the error payload
 - `409 conflict` when `followUpKind` does not match the parent request's current lifecycle state
 
@@ -681,7 +691,8 @@ Request body:
 
 - `leaveType`: optional when editing the pending request
 - `date`: optional when editing the pending request
-- `hours`: optional when editing the pending request
+- `startAt`: optional when editing the pending hourly request
+- `endAt`: optional when editing the pending hourly request
 - `reason`: optional when editing the pending request
 - `status`: optional; the only writable status value is `withdrawn`
 
@@ -690,13 +701,17 @@ Current-scope rules:
 - The request must currently have `status = pending`.
 - If `status = withdrawn`, omit the other editable fields.
 - If `status` is omitted, provide at least one employee-editable field.
+- If `date` is provided, the resulting request must still target today or a future workday in the first pass.
+- Hourly leave edits must still produce a valid `startAt`/`endAt` interval, and `hours` remains derived output rather than writable input.
+- The resulting request must still avoid overlap with another unsuperseded root leave chain for the same employee.
 - This endpoint never creates a follow-up request; approved-state leave change or cancel still requires `POST /api/leave/request` with `followUpKind`.
 
 Example request body:
 
 ```json
 {
-  "hours": 3,
+  "startAt": "2026-04-03T12:00:00+09:00",
+  "endAt": "2026-04-03T15:00:00+09:00",
   "reason": "The appointment window expanded."
 }
 ```
@@ -717,6 +732,8 @@ Response:
   "requestType": "leave",
   "leaveType": "hourly",
   "date": "2026-04-03",
+  "startAt": "2026-04-03T12:00:00+09:00",
+  "endAt": "2026-04-03T15:00:00+09:00",
   "hours": 3,
   "reason": "The appointment window expanded.",
   "status": "pending",
@@ -739,8 +756,9 @@ Response:
 
 Typical error cases:
 
-- `400 validation_error` when the payload mixes `status = withdrawn` with editable fields or otherwise violates the pending-edit contract
+- `400 validation_error` when the payload mixes `status = withdrawn` with editable fields, provides an invalid hourly interval, or otherwise violates the pending-edit contract
 - `404 not_found` when the request id does not exist
+- `409 conflict` when the edited request would overlap another unsuperseded root leave chain for the same employee
 - `409 conflict` when the request is no longer `pending`
 
 ### `PUT /api/leave/request/[id]/top-surface-suppression`

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -191,7 +191,8 @@ Represents a submitted leave application.
 | `requestType`           | enum           | always `leave`                                                                    |
 | `leaveType`             | enum           | `Leave Type`                                                                      |
 | `date`                  | string         | target leave date                                                                 |
-| `hours`                 | number or null | required only when `leaveType` is `hourly`                                        |
+| `startAt`               | string or null | required only when `leaveType` is `hourly`                                        |
+| `endAt`                 | string or null | required only when `leaveType` is `hourly`                                        |
 | `reason`                | string         | employee-provided note                                                            |
 | `status`                | enum           | `Request Status`                                                                  |
 | `requestedAt`           | string         | submission time                                                                   |
@@ -201,6 +202,14 @@ Represents a submitted leave application.
 | `parentRequestId`       | string or null | immediate earlier request for a follow-up; `null` on the root request             |
 | `followUpKind`          | enum or null   | `Follow-Up Kind` for follow-up requests; `null` on the root request               |
 | `supersededByRequestId` | string or null | later approved follow-up that supersedes this request                             |
+
+Hourly leave durations are derived from `startAt` and `endAt` and may be exposed in API and UI output as `hours`, but `hours` is not authoritative input on the canonical request entity.
+
+Important rules:
+
+- In the first pass, leave requests may target only today or a future workday.
+- Duplicate prevention is overlap-based, not type-label-based: the same employee cannot create a second unsuperseded root leave chain whose effective leave interval overlaps another unsuperseded root chain.
+- When `leaveType = hourly`, `startAt` and `endAt` are the authoritative interval fields and `hours` is derived output only.
 
 ### Employee Leave Top Surface Suppression
 

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -76,7 +76,7 @@ Required UI:
 - a stable top summary tier that always shows leave balance plus calm current-state context rather than escalating plain pending requests into the top correction surface
 - a conditional top correction tier for reviewed non-approved leave requests that still need employee attention without treating them as a shared queue state
 - a leave-only planning calendar with selected-date context directly below it
-- one inline leave composer below the calendar that supports annual leave, half-day AM, half-day PM, and hourly leave and owns new leave request, `resubmission`, approved-state `change`, and approved-state `cancel` flows
+- one inline leave composer below the calendar that supports annual leave, half-day AM, half-day PM, and hourly leave; hourly leave uses explicit `startAt`/`endAt` interval input and shows derived `hours` output rather than accepting `hours` as input, and the composer owns new leave request, `resubmission`, approved-state `change`, and approved-state `cancel` flows
 - a flat list of the current user's leave request chains, ordered by latest activity, with each row representing the current governing chain context rather than every request record as a separate top-level row
 - each leave-chain history row should summarize the governed date or date range, leave type, employee reason summary, current governing status, and latest review timing while earlier chain steps remain secondary chain detail rather than separate top-level rows
 - visible prior review comments and follow-up context when a leave request is `revision_requested` or `rejected`
@@ -99,10 +99,10 @@ Required UI:
 
 Validation and policy topics that must stay aligned with narrower contract documents:
 
-- whether past-date leave requests are allowed
-- how same-day duplicate requests are prevented
-- how hourly leave should be represented in the UI and payload
-- how approved leave should surface later attendance conflicts without silently overwriting the original leave decision
+- in the first pass, leave requests may target only today or a future workday
+- duplicate prevention is overlap-based, not type-label-based: the same employee cannot create a second unsuperseded root leave chain whose effective leave interval overlaps another unsuperseded root chain
+- hourly leave uses explicit `startAt` and `endAt` payload fields, and `hours` is derived display/output data rather than authoritative input
+- approved leave surfacing later attendance conflicts without silently overwriting the original leave decision stays owned by `docs/attendance-operating-model.md`
 - company-event conflict policy and staffing-cap warning behavior should follow `docs/leave-conflict-policy.md`
 
 ## Admin Flow Requirements

--- a/docs/leave-conflict-policy.md
+++ b/docs/leave-conflict-policy.md
@@ -7,6 +7,7 @@ It defines how company events, staffing capacity, and approval-side warning beha
 
 This document does not own request lifecycle semantics, attendance fact lifecycle, full HTTP payload definitions, or company-event management workflows.
 Those concerns remain in `docs/request-lifecycle-model.md`, `docs/attendance-operating-model.md`, `docs/api-spec.md`, `docs/database-schema.md`, and `docs/product-spec-context.md`.
+It also does not define requestable-date eligibility, duplicate-prevention rules, or the hourly leave write payload contract; those rules are locked in the feature, API, and schema docs.
 
 ## First-Pass Policy Defaults
 


### PR DESCRIPTION
## Summary
- lock the leave validation contract for issue #22
- keep leave eligibility and hourly write-shape rules explicit in the shared docs

## This PR locks
- leave requests as today-or-future workdays only in the first pass
- duplicate prevention by overlapping effective leave interval instead of leave-type label
- hourly leave using `startAt` and `endAt` as authoritative write fields
- `hours` as derived display/output data only
- validation ownership staying separate from company-event severity, staffing-cap approval behavior, and shared request lifecycle semantics

## Docs Touched
- `docs/api-spec.md`
- `docs/database-schema.md`
- `docs/feature-requirements.md`
- `docs/leave-conflict-policy.md`

## Downstream Impact
- `#30` and `#34` should consume these validation rules as fixed input.
- Follow-up issues should not reopen hourly write shape, date eligibility, or duplicate policy inside page/UI work.

## Validation
- `git diff --check`
- pre-push hook: `pnpm build`
- pre-push hook: `pnpm format:check`
- pre-push hook: `pnpm lint`
- pre-push hook: `pnpm test`

Refs #22
