### PR TITLE
ui: lock notification surface contract

### DIFF
--- a/docs/attendance-operating-model.md
+++ b/docs/attendance-operating-model.md
@@ -148,9 +148,10 @@ Priority guidance for same-day admin exception review:
 - Opening the app must never create attendance facts by itself.
 - Employee and admin views must stay synchronized on the same date-level facts and request state.
 - Important states must not stay buried in history tables when immediate action is needed.
+- When the same attendance fact or request state appears on multiple employee or admin surfaces, the highest-priority operational surface owns the next action and lower-priority copies are supporting context only.
 - Different causes must remain distinguishable. Failed attempts, missing check-ins, finalized absences, previous-day carry-over problems, leave conflicts, and request states are not interchangeable labels.
 - Every important attendance state should preserve the current state, the reason, and the next action.
-- A resolved approval, rejection, resubmission, or successful attendance correction must clear or replace stale warnings, badges, and CTAs.
+- A resolved approval, rejection, resubmission, withdrawal, or successful attendance correction must clear or replace stale warnings, badges, and CTAs.
 
 ### Forbidden Behaviors
 

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -182,7 +182,8 @@ Decision points for later issue planning:
 - Top-of-screen warnings should take priority over buried table-only states when the user needs immediate action.
 - Different causes must remain distinguishable: failed attempt, expected-but-missing check-in, finalized absence, previous-day missing checkout, leave-work conflict, and request-review state must not collapse into one vague warning.
 - Every important state should include the current state, the reason, and the next action.
-- Warning, badge, and CTA cleanup after approvals, rejections, or successful corrections must happen consistently across employee and admin surfaces.
+- Notification surfaces should be layered and deduplicated: summary cards, exception stacks, queue rows, detail panels, selected-date context, and history rows may repeat the same state only as supporting context; the highest-priority visible surface owns the primary next action.
+- Warning, badge, and CTA cleanup after approvals, rejections, resubmissions, withdrawals, or successful corrections must happen consistently across employee and admin surfaces, and stale lower-priority copies should disappear when the governing state changes.
 - Request surfaces should expose the same active request, effective status, and review comment to both employees and admins, while employee resubmission prompting may remain page-local.
 - On admin completed-history surfaces, the "next action" rule should not be interpreted as employee-resubmit guidance inside the admin workspace; those surfaces should read as no further admin action on the same record.
 - Employee and admin surfaces must interpret `rejected` and `revision_requested` as locked non-approved reviewed states on the same request record until a linked follow-up exists. Employee pages may promote resubmission entry points, while admin pages should treat those reviewed outcomes as completed review history rather than active queue work.

--- a/docs/request-lifecycle-model.md
+++ b/docs/request-lifecycle-model.md
@@ -16,6 +16,7 @@ Those concerns remain in `docs/product-spec-context.md`, `docs/api-spec.md`, `do
 - A reviewed non-approved outcome must keep the prior review comment visible together with any downstream resubmission entry point that page-level IA exposes.
 - A chain may have at most one active employee-submitted follow-up at a time.
 - Employee and admin views must stay synchronized on the same active request, effective status, review rationale, and whether a linked follow-up now governs the chain.
+- When the same request chain appears on more than one surface, the highest-priority active surface owns the primary next action; lower-priority copies are supporting context and must not keep competing CTAs alive after the chain state changes.
 - The current product does not allow a manager to directly reverse an already approved request.
 - Approved-state follow-up `change` and `cancel` flows are currently formalized only for leave requests.
 - Manual attendance requests currently support pre-review edit and withdrawal plus post-review resubmission, but not approved-state follow-up `change` or `cancel`.
@@ -233,6 +234,7 @@ Employee-only leave top-surface suppression is page-level visibility metadata. I
 - Approved manual-attendance requests must not advertise post-approval follow-up `change` or `cancel` in the current scope.
 - Latest activity and effective status must both be explainable from the same visible chain history.
 - Important request-state changes must clear or replace stale warnings, badges, queue states, and CTAs promptly.
+- Stale duplicate surfaces must not survive once the governing request state changes, even when employee and admin pages are both showing the same chain.
 
 ### Forbidden Behaviors
 

--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -66,6 +66,14 @@ The originating reference image is stored at `docs/assets/erp-reference-dashboar
 - Admin attendance views should prioritize exceptions over aggregate comfort metrics. The default today queue should group carry-over issues, unresolved failed attempts, request-related exceptions, and then simpler missing or late cases so unresolved operational risk is easier to notice than nominal counts.
 - Approved leave must suppress generic missing-check-in warnings for the covered period, but a later actual attendance fact on the same leave-covered day must surface as a leave-work conflict.
 
+## Notification Surface Taxonomy
+
+- Treat notification surfaces as layered: top summary cards, active exception stacks, queue rows, detail panels, selected-date context, confirmation surfaces, and history re-entry points.
+- One state may appear on more than one layer, but the highest-priority active surface owns the primary CTA; lower layers are supporting context and must not introduce competing primary actions.
+- When the governing state resolves, remove stale copies from lower-priority surfaces promptly instead of leaving duplicate warnings, badges, or CTAs behind.
+- Company-event warnings and staffing-cap risk remain warning/manual-review semantics on leave surfaces as fixed by `docs/leave-conflict-policy.md`; do not hard-block them or invent stronger employee-only admin states here.
+- Employee-only top-surface suppression is an employee visibility control only. Do not expose suppression metadata on admin surfaces.
+
 ## State Messaging Rules
 
 - Every important state should communicate the current state, the reason, and the next action.


### PR DESCRIPTION
## Summary
- lock the notification surface contract for issue #46
- keep primary-action ownership and stale-state cleanup explicit across employee and admin surfaces

## This PR locks
- layered notification surfaces across summary cards, exception stacks, queue rows, detail panels, selected-date context, confirmation surfaces, and history re-entry points
- one highest-priority active surface owning the primary next action for a state
- lower-priority copies as supporting context only, without competing primary actions
- stale lower-priority copies clearing after approvals, rejections, resubmissions, withdrawals, and successful corrections
- cross-surface deduplication rules for attendance and request state
- admin completed-history surfaces staying read-only and quiet
- employee-only suppression metadata never leaking into admin notification semantics

## Docs Touched
- `docs/attendance-operating-model.md`
- `docs/feature-requirements.md`
- `docs/request-lifecycle-model.md`
- `docs/ui-guidelines.md`

## Downstream Impact
- `#29`, `#30`, `#31`, `#32`, `#33`, `#34`, `#35`, and `#36` should consume this cleanup and surface-priority contract as fixed input.
- Follow-up issues should not reinterpret queue/history IA or leave-conflict policy inside notification cleanup work.

## Validation
- `git diff --check`
- pre-push hook: `pnpm build`
- pre-push hook: `pnpm format:check`
- pre-push hook: `pnpm lint`
- pre-push hook: `pnpm test`

Refs #46
