### PR TITLE
api: lock deterministic seed world contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Always consider using the shadcn mcp and shadcn skills first. Follow the mcp and
 - `docs/AGENTS.md`: documentation catalog, ownership matrix, and update triggers.
 - `docs/raw-assignment.md`: raw assignment input and local ERP reference image for documentation use.
 - `docs/product-spec-context.md`: living raw product-spec discussion log and cross-screen decision context.
+- `docs/seed-world-contract.md`: deterministic mock seed baseline, calendar window, and required scenario composition.
 - `docs/attendance-operating-model.md`: attendance runtime model, time-sequenced fact lifecycle, and shared exception semantics.
 - `docs/request-lifecycle-model.md`: request workflow model, follow-up-chain semantics, and shared employee/admin request synchronization rules.
 - `docs/leave-conflict-policy.md`: leave operational conflict policy, staffing-cap defaults, and company-event warning behavior.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -20,6 +20,7 @@ These files are meant to guide implementation, issue breakdown, and later mainte
 | `DESIGN.md`                          | design-agent visual system                            | design tokens, component style, or visual guardrails change                                                             |
 | `docs/raw-assignment.md`             | raw assignment input and original reference material  | the provided assignment text or local visual reference asset changes                                                    |
 | `docs/product-spec-context.md`       | living raw product-spec discussion log                | cross-screen spec discussions, locked defaults, or open product questions change                                        |
+| `docs/seed-world-contract.md`        | deterministic mock seed world contract                | baseline date, calendar window, or seeded scenario composition change                                                   |
 | `docs/attendance-operating-model.md` | attendance runtime flow and timeline semantics        | attendance fact lifecycle, derived exception timing, or cross-screen attendance synchronization rules change            |
 | `docs/request-lifecycle-model.md`    | request workflow semantics and follow-up chains       | reviewed-request change rules, follow-up chains, or cross-screen request synchronization rules change                   |
 | `docs/leave-conflict-policy.md`      | leave operational conflict policy                     | company-event conflict, staffing-cap policy, or leave approval warning rules change                                     |
@@ -38,6 +39,7 @@ These files are meant to guide implementation, issue breakdown, and later mainte
 - `DESIGN.md` owns the visual system and design-agent-facing tokens.
 - `docs/raw-assignment.md` owns the raw source text and local reference artifact list, but not interpreted product contracts.
 - `docs/product-spec-context.md` owns the living raw discussion log, cross-screen decision context, and open interview questions that have not yet been promoted into narrower contract documents.
+- `docs/seed-world-contract.md` owns the deterministic mock seed baseline, calendar window, employee composition, seeded scenario coverage, and read-only company-event inputs.
 - `docs/attendance-operating-model.md` owns the attendance fact lifecycle, derived attendance interpretation, and shared attendance timeline semantics.
 - `docs/request-lifecycle-model.md` owns reviewed-request lifecycle semantics, follow-up-chain rules, and shared employee/admin request-state synchronization.
 - `docs/leave-conflict-policy.md` owns company-event conflicts, staffing-cap policy, and leave-specific warning-versus-block defaults across employee and admin review surfaces.
@@ -51,6 +53,7 @@ These files are meant to guide implementation, issue breakdown, and later mainte
 - If a screen or workflow changes, update `docs/feature-requirements.md`.
 - If the source assignment or attached reference asset changes, update `docs/raw-assignment.md` and `docs/assets/` as needed.
 - If ongoing product-spec discussions establish new cross-screen principles, preserve raw context in `docs/product-spec-context.md` before promoting final decisions into narrower source-of-truth documents.
+- If the deterministic mock seed world, baseline date, or seeded scenario composition changes, update `docs/seed-world-contract.md` and any affected contract documents in the same change set.
 - If the attendance fact lifecycle, exception timing, or cross-screen attendance synchronization rules change, update `docs/attendance-operating-model.md` and any affected contract documents in the same change set.
 - If reviewed-request changes, follow-up-chain semantics, or request-state synchronization rules change, update `docs/request-lifecycle-model.md` and any affected contract documents in the same change set.
 - If company-event conflict policy, staffing-cap rules, or leave approval warning behavior changes, update `docs/leave-conflict-policy.md` and any affected feature or UI docs in the same change set.

--- a/docs/seed-world-contract.md
+++ b/docs/seed-world-contract.md
@@ -1,0 +1,60 @@
+# Deterministic Seed World Contract
+
+## Purpose
+
+This document is the primary source of truth for the deterministic mock seed world used by the shared attendance, leave, and request surfaces.
+It defines one fixed Asia/Seoul baseline date, one deterministic calendar window, and the minimum seeded scenario mix that the mock API and screens must share.
+
+This document does not redefine attendance, request, or leave semantics.
+Those contracts remain owned by `docs/attendance-operating-model.md`, `docs/request-lifecycle-model.md`, `docs/leave-conflict-policy.md`, `docs/feature-requirements.md`, `docs/api-spec.md`, and `docs/database-schema.md`.
+
+## Baseline
+
+| Setting          | Value                                       | Notes                                                                                        |
+| ---------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Timezone         | `Asia/Seoul`                                | All seeded datetimes use `+09:00`.                                                           |
+| Baseline date    | `2026-04-13`                                | Fixed current-date anchor for the seed world.                                                |
+| Baseline weekday | Monday                                      | The baseline stays aligned to a workweek start.                                              |
+| Calendar window  | `2026-03-23` through `2026-04-20` inclusive | Deterministic date range that gives about one month of attendance facts around the baseline. |
+
+## Seed Composition
+
+- Seed exactly 12 employees.
+- Keep the employee set fixed across runs.
+- Seed roughly one month of attendance facts inside the calendar window.
+- Include a realistic mix of normal days, late arrivals, early departures, missing records, failed attendance attempts, leave coverage, and carry-over handling.
+- Keep all company-event records read-only seeded inputs.
+
+## Required Scenario Coverage
+
+The seed world must include each of the following concrete cases at least once:
+
+| Scenario                               | Required fixed date or shape                                                                                                                             | Contract meaning                                                                                      |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Previous-day missing checkout          | `2026-04-13` must surface `previous_day_checkout_missing` from the prior workday so the baseline date itself proves the carry-over case.                 | The carry-over state must be visible on both employee and admin surfaces.                             |
+| Next-day checkout                      | `2026-04-15` must include a next-day checkout that closes the prior workday before `09:00` in Asia/Seoul time.                                           | The prior workday is closed by writeback instead of turning into a new workday checkout.              |
+| Failed attendance attempt              | At least one failed attendance attempt must remain visible on its target date, including a case that still matters after the baseline date.              | The seed world proves unresolved attempt-failed coverage instead of relying only on successful facts. |
+| Leave-work conflict                    | One seeded attendance fact on a leave-covered date, such as `2026-04-18`, must produce `leave_work_conflict`.                                            | Attendance and leave facts stay visible together instead of erasing one another.                      |
+| Company-event-sensitive leave date     | At least one leave request on `2026-04-16` must overlap a read-only seeded company event.                                                                | Leave conflict policy can read the seeded event without mutating it.                                  |
+| Staffing-sensitive full-day leave date | At least one full-day leave request on `2026-04-17` must hit staffing-sensitive warning context.                                                         | Admin approval coverage can exercise the staffing-risk path.                                          |
+| Manual-attendance request chain        | At least one manual-attendance chain must cover a root request, a review outcome, and a linked `resubmission` follow-up.                                 | The seed world proves request-chain synchronization for manual attendance.                            |
+| Manual-attendance edit and withdraw    | At least one pending manual-attendance request must be editable before review and at least one pending request must be withdrawable before review.       | The seed world proves the employee-side pre-review request flows that remain in scope.                |
+| Approved manual writeback              | At least one approved manual-attendance request must write back into the canonical `attendanceRecord` and clear the embedded `manualRequest` projection. | Approval must mutate the canonical attendance fact, not just the request row.                         |
+| Leave request chain                    | At least one leave chain must cover a root request plus a live follow-up such as `change` or `cancel`.                                                   | The seed world proves leave follow-up behavior on the same chain.                                     |
+| Reviewed non-approved leave history    | At least one reviewed non-approved leave request must keep `governingReviewComment` visible until a linked follow-up resolves it.                        | Completed-history treatment stays aligned with the request lifecycle model.                           |
+
+## Vocabulary Guardrails
+
+- Use only terms that already exist in the promoted docs.
+- Do not introduce new request statuses, new attendance exception names, or new leave categories in the seed contract.
+- Do not add a second timezone, a floating baseline date, or a seed-only calendar interpretation.
+- Do not treat company-event records as mutable workflow data.
+
+## Downstream Consumers
+
+This contract feeds the same mock world used by employee attendance, leave, and admin request surfaces.
+
+- `docs/attendance-operating-model.md` consumes the attendance fact coverage.
+- `docs/request-lifecycle-model.md` consumes the request-chain coverage.
+- `docs/leave-conflict-policy.md` consumes the company-event and staffing-sensitive leave inputs.
+- `docs/feature-requirements.md`, `docs/api-spec.md`, and `docs/database-schema.md` consume the shared seed vocabulary and deterministic date context.


### PR DESCRIPTION
## Summary
- lock the deterministic seed-world contract for issue #26
- register the seed-world document as a primary source of truth before runtime repository work begins

## This PR locks
- `docs/seed-world-contract.md` as the canonical seed-world source of truth
- `Asia/Seoul` as the only seed-world timezone
- baseline date `2026-04-13`
- deterministic calendar window `2026-03-23` through `2026-04-20`
- exactly 12 seeded employees
- required scenario anchors for previous-day missing checkout on the baseline date, next-day checkout writeback, unresolved failed attempt, leave-work conflict, company-event-sensitive and staffing-sensitive leave dates, pending manual edit/withdraw, leave follow-up history, and approved manual writeback
- company events as read-only seeded inputs

## Docs Touched
- `AGENTS.md`
- `docs/AGENTS.md`
- `docs/seed-world-contract.md`

## Downstream Impact
- `#84` should add the fixed Seoul clock and canonical seed entities against this contract.
- `#28` and downstream handler/page issues (`#29`-`#36`) should consume this seed-world baseline rather than inventing local date assumptions.

## Validation
- `git diff --check`
- pre-push hook: `pnpm build`
- pre-push hook: `pnpm format:check`
- pre-push hook: `pnpm lint`
- pre-push hook: `pnpm test`

Refs #26
