### PR TITLE
api: add fixed Seoul clock and canonical seed entities

### DIFF
--- a/lib/seed/entities.ts
+++ b/lib/seed/entities.ts
@@ -1,0 +1,417 @@
+import { z } from "zod";
+
+import {
+  apiDateSchema,
+  apiDateTimeSchema,
+  attendanceAttemptActionSchema,
+  attendanceAttemptStatusSchema,
+  attendanceRecordSourceSchema,
+  followUpKindSchema,
+  leaveTypeSchema,
+  manualAttendanceActionSchema,
+  requestReviewDecisionSchema,
+  requestStatusSchema,
+} from "@/lib/contracts/shared";
+
+export const employeeRoleSchema = z.enum(["employee", "admin"]);
+
+export const employeeEntitySchema = z.strictObject({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  department: z.string().min(1),
+  role: employeeRoleSchema,
+});
+
+export const expectedWorkdayEntitySchema = z.strictObject({
+  id: z.string().min(1),
+  employeeId: z.string().min(1),
+  date: apiDateSchema,
+  isWorkday: z.boolean(),
+  expectedClockInAt: apiDateTimeSchema.nullable(),
+  expectedClockOutAt: apiDateTimeSchema.nullable(),
+  adjustedClockInAt: apiDateTimeSchema.nullable(),
+  adjustedClockOutAt: apiDateTimeSchema.nullable(),
+  countsTowardAdminSummary: z.boolean(),
+});
+
+export const attendanceAttemptEntitySchema = z
+  .strictObject({
+    id: z.string().min(1),
+    employeeId: z.string().min(1),
+    date: apiDateSchema,
+    action: attendanceAttemptActionSchema,
+    attemptedAt: apiDateTimeSchema,
+    status: attendanceAttemptStatusSchema,
+    failureReason: z.string().min(1).nullable(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.status === "success" && value.failureReason !== null) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["failureReason"],
+        message:
+          'Invalid input: "failureReason" must be null when the attempt status is "success"',
+      });
+    }
+
+    if (value.status === "failed" && value.failureReason === null) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["failureReason"],
+        message:
+          'Invalid input: "failureReason" is required when the attempt status is "failed"',
+      });
+    }
+  });
+
+export const attendanceRecordEntitySchema = z.strictObject({
+  id: z.string().min(1),
+  employeeId: z.string().min(1),
+  date: apiDateSchema,
+  clockInAt: apiDateTimeSchema.nullable(),
+  clockInSource: attendanceRecordSourceSchema.nullable(),
+  clockOutAt: apiDateTimeSchema.nullable(),
+  clockOutSource: attendanceRecordSourceSchema.nullable(),
+  workMinutes: z.number().int().nonnegative().nullable(),
+  manualRequestId: z.string().min(1).nullable(),
+});
+
+const requestReviewStateEntitySchema = z.object({
+  status: requestStatusSchema,
+  reviewedAt: apiDateTimeSchema.nullable(),
+  reviewComment: z.string().min(1).nullable(),
+});
+
+const requestRelationEntitySchema = z.object({
+  rootRequestId: z.string().min(1),
+  parentRequestId: z.string().min(1).nullable(),
+  followUpKind: followUpKindSchema.nullable(),
+  supersededByRequestId: z.string().min(1).nullable(),
+});
+
+function validateRequestLifecycleFields(
+  value: {
+    status: z.infer<typeof requestStatusSchema>;
+    reviewedAt: z.infer<typeof apiDateTimeSchema> | null;
+    reviewComment: string | null;
+  },
+  ctx: z.RefinementCtx,
+) {
+  const requiresReviewedAt =
+    value.status === "approved" ||
+    value.status === "rejected" ||
+    value.status === "revision_requested";
+  const requiresReviewComment =
+    value.status === "rejected" || value.status === "revision_requested";
+
+  if (requiresReviewedAt && value.reviewedAt === null) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["reviewedAt"],
+      message:
+        'Invalid input: "reviewedAt" is required for reviewed request entities',
+    });
+  }
+
+  if (!requiresReviewedAt && value.reviewedAt !== null) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["reviewedAt"],
+      message:
+        'Invalid input: "reviewedAt" must be null unless the request is approved, rejected, or revision_requested',
+    });
+  }
+
+  if (requiresReviewComment && value.reviewComment === null) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["reviewComment"],
+      message:
+        'Invalid input: "reviewComment" is required when the request is rejected or revision_requested',
+    });
+  }
+
+  if (!requiresReviewComment && value.reviewComment !== null) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["reviewComment"],
+      message:
+        'Invalid input: "reviewComment" must be null unless the request is rejected or revision_requested',
+    });
+  }
+}
+
+export const requestReviewEventEntitySchema = z
+  .strictObject({
+    id: z.string().min(1),
+    requestId: z.string().min(1),
+    decision: requestReviewDecisionSchema,
+    reviewComment: z.string().min(1).nullable(),
+    reviewedAt: apiDateTimeSchema,
+    reviewerId: z.string().min(1),
+  })
+  .superRefine((value, ctx) => {
+    if (value.decision === "approve" && value.reviewComment !== null) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["reviewComment"],
+        message:
+          'Invalid input: "reviewComment" must be null when the review decision is "approve"',
+      });
+    }
+
+    if (value.decision !== "approve" && value.reviewComment === null) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["reviewComment"],
+        message:
+          'Invalid input: "reviewComment" is required when the review decision is not "approve"',
+      });
+    }
+  });
+
+export const companyEventEntitySchema = z.strictObject({
+  id: z.string().min(1),
+  date: apiDateSchema,
+  title: z.string().min(1),
+});
+
+export const manualAttendanceRequestEntitySchema = z
+  .strictObject({
+    id: z.string().min(1),
+    employeeId: z.string().min(1),
+    requestType: z.literal("manual_attendance"),
+    action: manualAttendanceActionSchema,
+    date: apiDateSchema,
+    submittedAt: apiDateTimeSchema,
+    requestedClockInAt: apiDateTimeSchema.nullable(),
+    requestedClockOutAt: apiDateTimeSchema.nullable(),
+    reason: z.string().min(1),
+    ...requestReviewStateEntitySchema.shape,
+    ...requestRelationEntitySchema.shape,
+  })
+  .superRefine((value, ctx) => {
+    validateRequestLifecycleFields(value, ctx);
+
+    if (value.action === "clock_in") {
+      if (value.requestedClockInAt === null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["requestedClockInAt"],
+          message:
+            'Invalid input: "requestedClockInAt" is required when "action" is "clock_in"',
+        });
+      }
+
+      if (value.requestedClockOutAt !== null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["requestedClockOutAt"],
+          message:
+            'Invalid input: "requestedClockOutAt" must be null when "action" is "clock_in"',
+        });
+      }
+    }
+
+    if (value.action === "clock_out") {
+      if (value.requestedClockOutAt === null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["requestedClockOutAt"],
+          message:
+            'Invalid input: "requestedClockOutAt" is required when "action" is "clock_out"',
+        });
+      }
+
+      if (value.requestedClockInAt !== null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["requestedClockInAt"],
+          message:
+            'Invalid input: "requestedClockInAt" must be null when "action" is "clock_out"',
+        });
+      }
+    }
+
+    if (value.action === "both") {
+      if (value.requestedClockInAt === null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["requestedClockInAt"],
+          message:
+            'Invalid input: "requestedClockInAt" is required when "action" is "both"',
+        });
+      }
+
+      if (value.requestedClockOutAt === null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["requestedClockOutAt"],
+          message:
+            'Invalid input: "requestedClockOutAt" is required when "action" is "both"',
+        });
+      }
+    }
+
+    const hasParentRequestId = value.parentRequestId !== null;
+    const hasFollowUpKind = value.followUpKind !== null;
+
+    if (hasParentRequestId && !hasFollowUpKind) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["followUpKind"],
+        message:
+          'Invalid input: "followUpKind" is required when "parentRequestId" is present',
+      });
+    }
+
+    if (!hasParentRequestId && hasFollowUpKind) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["parentRequestId"],
+        message:
+          'Invalid input: "parentRequestId" is required when "followUpKind" is present',
+      });
+    }
+
+    if (!hasParentRequestId && value.rootRequestId !== value.id) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["rootRequestId"],
+        message:
+          'Invalid input: "rootRequestId" must equal "id" for a root manual attendance request',
+      });
+    }
+
+    if (hasParentRequestId && value.rootRequestId === value.id) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["rootRequestId"],
+        message:
+          'Invalid input: "rootRequestId" must point to the root manual attendance request',
+      });
+    }
+
+    if (value.followUpKind !== null && value.followUpKind !== "resubmission") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["followUpKind"],
+        message:
+          'Invalid input: "followUpKind" must be null or "resubmission" for manual attendance requests',
+      });
+    }
+  });
+
+export const leaveRequestEntitySchema = z
+  .strictObject({
+    id: z.string().min(1),
+    employeeId: z.string().min(1),
+    requestType: z.literal("leave"),
+    leaveType: leaveTypeSchema,
+    date: apiDateSchema,
+    startAt: apiDateTimeSchema.nullable(),
+    endAt: apiDateTimeSchema.nullable(),
+    reason: z.string().min(1),
+    requestedAt: apiDateTimeSchema,
+    ...requestReviewStateEntitySchema.shape,
+    ...requestRelationEntitySchema.shape,
+  })
+  .superRefine((value, ctx) => {
+    validateRequestLifecycleFields(value, ctx);
+
+    if (value.leaveType === "hourly") {
+      if (value.startAt === null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["startAt"],
+          message:
+            'Invalid input: "startAt" is required when "leaveType" is "hourly"',
+        });
+      }
+
+      if (value.endAt === null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["endAt"],
+          message:
+            'Invalid input: "endAt" is required when "leaveType" is "hourly"',
+        });
+      }
+    }
+
+    if (value.leaveType !== "hourly") {
+      if (value.startAt !== null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["startAt"],
+          message:
+            'Invalid input: "startAt" must be null unless "leaveType" is "hourly"',
+        });
+      }
+
+      if (value.endAt !== null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["endAt"],
+          message:
+            'Invalid input: "endAt" must be null unless "leaveType" is "hourly"',
+        });
+      }
+    }
+
+    const hasParentRequestId = value.parentRequestId !== null;
+    const hasFollowUpKind = value.followUpKind !== null;
+
+    if (hasParentRequestId && !hasFollowUpKind) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["followUpKind"],
+        message:
+          'Invalid input: "followUpKind" is required when "parentRequestId" is present',
+      });
+    }
+
+    if (!hasParentRequestId && hasFollowUpKind) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["parentRequestId"],
+        message:
+          'Invalid input: "parentRequestId" is required when "followUpKind" is present',
+      });
+    }
+
+    if (!hasParentRequestId && value.rootRequestId !== value.id) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["rootRequestId"],
+        message:
+          'Invalid input: "rootRequestId" must equal "id" for a root leave request',
+      });
+    }
+
+    if (hasParentRequestId && value.rootRequestId === value.id) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["rootRequestId"],
+        message:
+          'Invalid input: "rootRequestId" must point to the root leave request',
+      });
+    }
+  });
+
+export type EmployeeEntity = z.infer<typeof employeeEntitySchema>;
+export type ExpectedWorkdayEntity = z.infer<typeof expectedWorkdayEntitySchema>;
+export type AttendanceAttemptEntity = z.infer<
+  typeof attendanceAttemptEntitySchema
+>;
+export type AttendanceRecordEntity = z.infer<
+  typeof attendanceRecordEntitySchema
+>;
+export type RequestReviewEventEntity = z.infer<
+  typeof requestReviewEventEntitySchema
+>;
+export type CompanyEventEntity = z.infer<typeof companyEventEntitySchema>;
+export type ManualAttendanceRequestEntity = z.infer<
+  typeof manualAttendanceRequestEntitySchema
+>;
+export type LeaveRequestEntity = z.infer<typeof leaveRequestEntitySchema>;

--- a/lib/seed/index.ts
+++ b/lib/seed/index.ts
@@ -1,0 +1,3 @@
+export * from "@/lib/seed/entities";
+export * from "@/lib/seed/seoul-clock";
+export * from "@/lib/seed/world";

--- a/lib/seed/seoul-clock.ts
+++ b/lib/seed/seoul-clock.ts
@@ -1,0 +1,12 @@
+export const fixedSeoulTimeZone = "Asia/Seoul" as const;
+export const fixedSeoulUtcOffset = "+09:00" as const;
+export const fixedSeoulBaselineDate = "2026-04-13" as const;
+
+export const fixedSeoulCalendarWindow = Object.freeze({
+  start: "2026-03-23",
+  end: "2026-04-20",
+} as const);
+
+export function buildFixedSeoulDateTime(date: string, time: string) {
+  return `${date}T${time}${fixedSeoulUtcOffset}`;
+}

--- a/lib/seed/world.ts
+++ b/lib/seed/world.ts
@@ -1,0 +1,964 @@
+import {
+  attendanceAttemptEntitySchema,
+  attendanceRecordEntitySchema,
+  companyEventEntitySchema,
+  employeeEntitySchema,
+  expectedWorkdayEntitySchema,
+  leaveRequestEntitySchema,
+  manualAttendanceRequestEntitySchema,
+  requestReviewEventEntitySchema,
+} from "@/lib/seed/entities";
+import {
+  buildFixedSeoulDateTime,
+  fixedSeoulBaselineDate,
+  fixedSeoulCalendarWindow,
+} from "@/lib/seed/seoul-clock";
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+
+  Object.freeze(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      deepFreeze(item);
+    }
+    return value;
+  }
+
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    deepFreeze(child);
+  }
+
+  return value;
+}
+
+function listDateRange(start: string, end: string) {
+  const dates: string[] = [];
+  const cursor = new Date(`${start}T00:00:00Z`);
+  const last = new Date(`${end}T00:00:00Z`);
+
+  while (cursor.getTime() <= last.getTime()) {
+    dates.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+
+  return dates;
+}
+
+function isWeekend(date: string) {
+  const day = new Date(`${date}T00:00:00Z`).getUTCDay();
+  return day === 0 || day === 6;
+}
+
+const seededSpecialWorkdays = new Set(["2026-04-18"]);
+
+function workdayId(employeeId: string, date: string) {
+  return `expected_workday_${employeeId}_${date}`;
+}
+
+function attendanceAttemptId(
+  employeeId: string,
+  date: string,
+  action: "clock_in" | "clock_out",
+  status: "success" | "failed",
+) {
+  return `attendance_attempt_${employeeId}_${date}_${action}${
+    status === "failed" ? "_failed" : ""
+  }`;
+}
+
+function attendanceRecordId(employeeId: string, date: string) {
+  return `attendance_record_${employeeId}_${date}`;
+}
+
+function manualRequestId(
+  employeeId: string,
+  date: string,
+  suffix: "root" | "resubmission",
+) {
+  return `manual_request_${employeeId}_${date}_${suffix}`;
+}
+
+function leaveRequestId(
+  employeeId: string,
+  date: string,
+  suffix: "root" | "change" | "resubmission",
+) {
+  return `leave_request_${employeeId}_${date}_${suffix}`;
+}
+
+const employees = deepFreeze(
+  employeeEntitySchema.array().parse([
+    {
+      id: "emp_001",
+      name: "Minji Park",
+      department: "Operations",
+      role: "employee",
+    },
+    {
+      id: "emp_002",
+      name: "Junho Lee",
+      department: "Engineering",
+      role: "employee",
+    },
+    {
+      id: "emp_003",
+      name: "Hana Choi",
+      department: "Customer Success",
+      role: "employee",
+    },
+    {
+      id: "emp_004",
+      name: "Seungwoo Kim",
+      department: "Sales",
+      role: "employee",
+    },
+    {
+      id: "emp_005",
+      name: "Yuna Kang",
+      department: "Finance",
+      role: "employee",
+    },
+    {
+      id: "emp_006",
+      name: "Daeho Jung",
+      department: "Product",
+      role: "employee",
+    },
+    {
+      id: "emp_007",
+      name: "Jisoo Lim",
+      department: "Operations",
+      role: "employee",
+    },
+    {
+      id: "emp_008",
+      name: "Taeyang Shin",
+      department: "Engineering",
+      role: "employee",
+    },
+    { id: "emp_009", name: "Sora Moon", department: "HR", role: "employee" },
+    {
+      id: "emp_010",
+      name: "Hyunwoo Baek",
+      department: "Support",
+      role: "employee",
+    },
+    { id: "emp_011", name: "Nari Oh", department: "Finance", role: "employee" },
+    { id: "emp_012", name: "Jiwon Han", department: "People", role: "admin" },
+  ]),
+);
+
+const calendarDates = listDateRange(
+  fixedSeoulCalendarWindow.start,
+  fixedSeoulCalendarWindow.end,
+);
+
+const expectedWorkdays = deepFreeze(
+  expectedWorkdayEntitySchema.array().parse(
+    employees.flatMap((employee) =>
+      calendarDates.map((date) => {
+        // The seed contract explicitly uses 2026-04-18 for a leave-work conflict,
+        // so that date stays a seeded operational workday even though it falls on a weekend.
+        const weekend = isWeekend(date) && !seededSpecialWorkdays.has(date);
+        const leaveOverride =
+          (employee.id === "emp_004" && date === "2026-04-16") ||
+          (employee.id === "emp_005" && date === "2026-04-18");
+
+        return {
+          id: workdayId(employee.id, date),
+          employeeId: employee.id,
+          date,
+          isWorkday: !weekend,
+          expectedClockInAt: weekend
+            ? null
+            : buildFixedSeoulDateTime(date, "09:00:00"),
+          expectedClockOutAt: weekend
+            ? null
+            : buildFixedSeoulDateTime(date, "18:00:00"),
+          adjustedClockInAt:
+            weekend || leaveOverride
+              ? null
+              : buildFixedSeoulDateTime(date, "09:00:00"),
+          adjustedClockOutAt:
+            weekend || leaveOverride
+              ? null
+              : buildFixedSeoulDateTime(date, "18:00:00"),
+          countsTowardAdminSummary: !weekend,
+        };
+      }),
+    ),
+  ),
+);
+
+function minutesBetween(startAt: string, endAt: string) {
+  return Math.round(
+    (new Date(endAt).getTime() - new Date(startAt).getTime()) / 60000,
+  );
+}
+
+const attendanceAttempts = deepFreeze(
+  attendanceAttemptEntitySchema.array().parse([
+    {
+      id: attendanceAttemptId("emp_001", "2026-04-10", "clock_in", "success"),
+      employeeId: "emp_001",
+      date: "2026-04-10",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-10", "08:56:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_001", "2026-04-11", "clock_in", "success"),
+      employeeId: "emp_001",
+      date: "2026-04-11",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-11", "09:12:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_001", "2026-04-11", "clock_out", "success"),
+      employeeId: "emp_001",
+      date: "2026-04-11",
+      action: "clock_out",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-11", "18:04:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_002", "2026-04-02", "clock_in", "success"),
+      employeeId: "emp_002",
+      date: "2026-04-02",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-02", "09:05:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_002", "2026-04-02", "clock_out", "success"),
+      employeeId: "emp_002",
+      date: "2026-04-02",
+      action: "clock_out",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-02", "18:00:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_002", "2026-04-14", "clock_in", "success"),
+      employeeId: "emp_002",
+      date: "2026-04-14",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-14", "09:02:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_002", "2026-04-14", "clock_out", "success"),
+      employeeId: "emp_002",
+      date: "2026-04-14",
+      action: "clock_out",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-15", "08:45:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_003", "2026-04-16", "clock_out", "failed"),
+      employeeId: "emp_003",
+      date: "2026-04-16",
+      action: "clock_out",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-16", "18:10:00"),
+      status: "failed",
+      failureReason: "Bluetooth beacon was unavailable at checkout.",
+    },
+    {
+      id: attendanceAttemptId("emp_004", "2026-04-01", "clock_in", "success"),
+      employeeId: "emp_004",
+      date: "2026-04-01",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-01", "09:17:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_004", "2026-04-01", "clock_out", "success"),
+      employeeId: "emp_004",
+      date: "2026-04-01",
+      action: "clock_out",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-01", "18:20:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_005", "2026-04-18", "clock_in", "success"),
+      employeeId: "emp_005",
+      date: "2026-04-18",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-18", "09:01:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_005", "2026-04-18", "clock_out", "success"),
+      employeeId: "emp_005",
+      date: "2026-04-18",
+      action: "clock_out",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-18", "18:03:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_006", "2026-04-04", "clock_in", "success"),
+      employeeId: "emp_006",
+      date: "2026-04-04",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-04", "09:01:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_006", "2026-04-04", "clock_out", "success"),
+      employeeId: "emp_006",
+      date: "2026-04-04",
+      action: "clock_out",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-04", "17:45:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_007", "2026-04-03", "clock_in", "success"),
+      employeeId: "emp_007",
+      date: "2026-04-03",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-03", "09:00:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_008", "2026-04-09", "clock_in", "success"),
+      employeeId: "emp_008",
+      date: "2026-04-09",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-09", "09:11:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_008", "2026-04-09", "clock_out", "success"),
+      employeeId: "emp_008",
+      date: "2026-04-09",
+      action: "clock_out",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-09", "17:12:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_010", "2026-04-13", "clock_in", "failed"),
+      employeeId: "emp_010",
+      date: "2026-04-13",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-13", "09:08:00"),
+      status: "failed",
+      failureReason: "The phone app could not reach the beacon service.",
+    },
+    {
+      id: attendanceAttemptId("emp_011", "2026-04-11", "clock_in", "success"),
+      employeeId: "emp_011",
+      date: "2026-04-11",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-11", "09:00:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_011", "2026-04-11", "clock_out", "success"),
+      employeeId: "emp_011",
+      date: "2026-04-11",
+      action: "clock_out",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-11", "17:40:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_012", "2026-04-14", "clock_in", "success"),
+      employeeId: "emp_012",
+      date: "2026-04-14",
+      action: "clock_in",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-14", "09:24:00"),
+      status: "success",
+      failureReason: null,
+    },
+    {
+      id: attendanceAttemptId("emp_012", "2026-04-14", "clock_out", "success"),
+      employeeId: "emp_012",
+      date: "2026-04-14",
+      action: "clock_out",
+      attemptedAt: buildFixedSeoulDateTime("2026-04-14", "18:10:00"),
+      status: "success",
+      failureReason: null,
+    },
+  ]),
+);
+
+const attendanceRecords = deepFreeze(
+  attendanceRecordEntitySchema.array().parse([
+    {
+      id: attendanceRecordId("emp_001", "2026-04-10"),
+      employeeId: "emp_001",
+      date: "2026-04-10",
+      clockInAt: buildFixedSeoulDateTime("2026-04-10", "08:56:00"),
+      clockInSource: "beacon",
+      clockOutAt: null,
+      clockOutSource: null,
+      workMinutes: null,
+      manualRequestId: null,
+    },
+    {
+      id: attendanceRecordId("emp_001", "2026-04-11"),
+      employeeId: "emp_001",
+      date: "2026-04-11",
+      clockInAt: buildFixedSeoulDateTime("2026-04-11", "09:12:00"),
+      clockInSource: "beacon",
+      clockOutAt: buildFixedSeoulDateTime("2026-04-11", "18:04:00"),
+      clockOutSource: "beacon",
+      workMinutes: minutesBetween(
+        buildFixedSeoulDateTime("2026-04-11", "09:12:00"),
+        buildFixedSeoulDateTime("2026-04-11", "18:04:00"),
+      ),
+      manualRequestId: null,
+    },
+    {
+      id: attendanceRecordId("emp_002", "2026-04-02"),
+      employeeId: "emp_002",
+      date: "2026-04-02",
+      clockInAt: buildFixedSeoulDateTime("2026-04-02", "09:05:00"),
+      clockInSource: "beacon",
+      clockOutAt: buildFixedSeoulDateTime("2026-04-02", "18:00:00"),
+      clockOutSource: "beacon",
+      workMinutes: minutesBetween(
+        buildFixedSeoulDateTime("2026-04-02", "09:05:00"),
+        buildFixedSeoulDateTime("2026-04-02", "18:00:00"),
+      ),
+      manualRequestId: null,
+    },
+    {
+      id: attendanceRecordId("emp_002", "2026-04-14"),
+      employeeId: "emp_002",
+      date: "2026-04-14",
+      clockInAt: buildFixedSeoulDateTime("2026-04-14", "09:02:00"),
+      clockInSource: "beacon",
+      clockOutAt: buildFixedSeoulDateTime("2026-04-15", "08:45:00"),
+      clockOutSource: "beacon",
+      workMinutes: minutesBetween(
+        buildFixedSeoulDateTime("2026-04-14", "09:02:00"),
+        buildFixedSeoulDateTime("2026-04-15", "08:45:00"),
+      ),
+      manualRequestId: null,
+    },
+    {
+      id: attendanceRecordId("emp_004", "2026-04-01"),
+      employeeId: "emp_004",
+      date: "2026-04-01",
+      clockInAt: buildFixedSeoulDateTime("2026-04-01", "09:17:00"),
+      clockInSource: "beacon",
+      clockOutAt: buildFixedSeoulDateTime("2026-04-01", "18:20:00"),
+      clockOutSource: "beacon",
+      workMinutes: minutesBetween(
+        buildFixedSeoulDateTime("2026-04-01", "09:17:00"),
+        buildFixedSeoulDateTime("2026-04-01", "18:20:00"),
+      ),
+      manualRequestId: null,
+    },
+    {
+      id: attendanceRecordId("emp_005", "2026-04-18"),
+      employeeId: "emp_005",
+      date: "2026-04-18",
+      clockInAt: buildFixedSeoulDateTime("2026-04-18", "09:01:00"),
+      clockInSource: "beacon",
+      clockOutAt: buildFixedSeoulDateTime("2026-04-18", "18:03:00"),
+      clockOutSource: "beacon",
+      workMinutes: minutesBetween(
+        buildFixedSeoulDateTime("2026-04-18", "09:01:00"),
+        buildFixedSeoulDateTime("2026-04-18", "18:03:00"),
+      ),
+      manualRequestId: null,
+    },
+    {
+      id: attendanceRecordId("emp_006", "2026-04-04"),
+      employeeId: "emp_006",
+      date: "2026-04-04",
+      clockInAt: buildFixedSeoulDateTime("2026-04-04", "09:01:00"),
+      clockInSource: "beacon",
+      clockOutAt: buildFixedSeoulDateTime("2026-04-04", "17:45:00"),
+      clockOutSource: "beacon",
+      workMinutes: minutesBetween(
+        buildFixedSeoulDateTime("2026-04-04", "09:01:00"),
+        buildFixedSeoulDateTime("2026-04-04", "17:45:00"),
+      ),
+      manualRequestId: null,
+    },
+    {
+      id: attendanceRecordId("emp_007", "2026-04-03"),
+      employeeId: "emp_007",
+      date: "2026-04-03",
+      clockInAt: buildFixedSeoulDateTime("2026-04-03", "09:00:00"),
+      clockInSource: "beacon",
+      clockOutAt: buildFixedSeoulDateTime("2026-04-03", "18:05:00"),
+      clockOutSource: "manual",
+      workMinutes: minutesBetween(
+        buildFixedSeoulDateTime("2026-04-03", "09:00:00"),
+        buildFixedSeoulDateTime("2026-04-03", "18:05:00"),
+      ),
+      manualRequestId: manualRequestId("emp_007", "2026-04-03", "root"),
+    },
+    {
+      id: attendanceRecordId("emp_008", "2026-04-09"),
+      employeeId: "emp_008",
+      date: "2026-04-09",
+      clockInAt: buildFixedSeoulDateTime("2026-04-09", "09:11:00"),
+      clockInSource: "beacon",
+      clockOutAt: buildFixedSeoulDateTime("2026-04-09", "17:12:00"),
+      clockOutSource: "beacon",
+      workMinutes: minutesBetween(
+        buildFixedSeoulDateTime("2026-04-09", "09:11:00"),
+        buildFixedSeoulDateTime("2026-04-09", "17:12:00"),
+      ),
+      manualRequestId: null,
+    },
+    {
+      id: attendanceRecordId("emp_011", "2026-04-11"),
+      employeeId: "emp_011",
+      date: "2026-04-11",
+      clockInAt: buildFixedSeoulDateTime("2026-04-11", "09:00:00"),
+      clockInSource: "beacon",
+      clockOutAt: buildFixedSeoulDateTime("2026-04-11", "17:40:00"),
+      clockOutSource: "beacon",
+      workMinutes: minutesBetween(
+        buildFixedSeoulDateTime("2026-04-11", "09:00:00"),
+        buildFixedSeoulDateTime("2026-04-11", "17:40:00"),
+      ),
+      manualRequestId: null,
+    },
+    {
+      id: attendanceRecordId("emp_012", "2026-04-14"),
+      employeeId: "emp_012",
+      date: "2026-04-14",
+      clockInAt: buildFixedSeoulDateTime("2026-04-14", "09:24:00"),
+      clockInSource: "beacon",
+      clockOutAt: buildFixedSeoulDateTime("2026-04-14", "18:10:00"),
+      clockOutSource: "beacon",
+      workMinutes: minutesBetween(
+        buildFixedSeoulDateTime("2026-04-14", "09:24:00"),
+        buildFixedSeoulDateTime("2026-04-14", "18:10:00"),
+      ),
+      manualRequestId: null,
+    },
+  ]),
+);
+
+const manualAttendanceRequests = deepFreeze(
+  manualAttendanceRequestEntitySchema.array().parse([
+    {
+      id: manualRequestId("emp_007", "2026-04-03", "root"),
+      employeeId: "emp_007",
+      requestType: "manual_attendance",
+      action: "clock_out",
+      date: "2026-04-03",
+      submittedAt: buildFixedSeoulDateTime("2026-04-03", "17:55:00"),
+      requestedClockInAt: null,
+      requestedClockOutAt: buildFixedSeoulDateTime("2026-04-03", "18:05:00"),
+      reason: "Checkout beacon was unavailable after the shift ended.",
+      status: "approved",
+      reviewedAt: buildFixedSeoulDateTime("2026-04-04", "09:15:00"),
+      reviewComment: null,
+      rootRequestId: manualRequestId("emp_007", "2026-04-03", "root"),
+      parentRequestId: null,
+      followUpKind: null,
+      supersededByRequestId: null,
+    },
+    {
+      id: manualRequestId("emp_009", "2026-04-08", "root"),
+      employeeId: "emp_009",
+      requestType: "manual_attendance",
+      action: "clock_in",
+      date: "2026-04-08",
+      submittedAt: buildFixedSeoulDateTime("2026-04-08", "11:05:00"),
+      requestedClockInAt: buildFixedSeoulDateTime("2026-04-08", "09:08:00"),
+      requestedClockOutAt: null,
+      reason: "The beacon app did not detect the office entrance.",
+      status: "rejected",
+      reviewedAt: buildFixedSeoulDateTime("2026-04-08", "14:20:00"),
+      reviewComment: "Please resubmit with a clearer arrival note.",
+      rootRequestId: manualRequestId("emp_009", "2026-04-08", "root"),
+      parentRequestId: null,
+      followUpKind: null,
+      supersededByRequestId: null,
+    },
+    {
+      id: manualRequestId("emp_009", "2026-04-08", "resubmission"),
+      employeeId: "emp_009",
+      requestType: "manual_attendance",
+      action: "clock_in",
+      date: "2026-04-08",
+      submittedAt: buildFixedSeoulDateTime("2026-04-08", "16:05:00"),
+      requestedClockInAt: buildFixedSeoulDateTime("2026-04-08", "09:08:00"),
+      requestedClockOutAt: null,
+      reason:
+        "I arrived at the office at 09:08 and the beacon still did not register.",
+      status: "pending",
+      reviewedAt: null,
+      reviewComment: null,
+      rootRequestId: manualRequestId("emp_009", "2026-04-08", "root"),
+      parentRequestId: manualRequestId("emp_009", "2026-04-08", "root"),
+      followUpKind: "resubmission",
+      supersededByRequestId: null,
+    },
+    {
+      id: manualRequestId("emp_010", "2026-04-09", "root"),
+      employeeId: "emp_010",
+      requestType: "manual_attendance",
+      action: "clock_in",
+      date: "2026-04-09",
+      submittedAt: buildFixedSeoulDateTime("2026-04-09", "11:35:00"),
+      requestedClockInAt: buildFixedSeoulDateTime("2026-04-09", "09:07:00"),
+      requestedClockOutAt: null,
+      reason:
+        "I need to correct the missing morning attendance note before review.",
+      status: "pending",
+      reviewedAt: null,
+      reviewComment: null,
+      rootRequestId: manualRequestId("emp_010", "2026-04-09", "root"),
+      parentRequestId: null,
+      followUpKind: null,
+      supersededByRequestId: null,
+    },
+    {
+      id: manualRequestId("emp_011", "2026-04-07", "root"),
+      employeeId: "emp_011",
+      requestType: "manual_attendance",
+      action: "both",
+      date: "2026-04-07",
+      submittedAt: buildFixedSeoulDateTime("2026-04-07", "18:50:00"),
+      requestedClockInAt: buildFixedSeoulDateTime("2026-04-07", "09:04:00"),
+      requestedClockOutAt: buildFixedSeoulDateTime("2026-04-07", "18:01:00"),
+      reason:
+        "Please correct both attendance facts from the office network outage.",
+      status: "pending",
+      reviewedAt: null,
+      reviewComment: null,
+      rootRequestId: manualRequestId("emp_011", "2026-04-07", "root"),
+      parentRequestId: null,
+      followUpKind: null,
+      supersededByRequestId: null,
+    },
+    {
+      id: manualRequestId("emp_010", "2026-04-13", "root"),
+      employeeId: "emp_010",
+      requestType: "manual_attendance",
+      action: "clock_in",
+      date: "2026-04-13",
+      submittedAt: buildFixedSeoulDateTime("2026-04-13", "09:20:00"),
+      requestedClockInAt: buildFixedSeoulDateTime("2026-04-13", "09:08:00"),
+      requestedClockOutAt: null,
+      reason: "Beacon connectivity failed during baseline check-in.",
+      status: "rejected",
+      reviewedAt: buildFixedSeoulDateTime("2026-04-13", "14:00:00"),
+      reviewComment: "Please submit a follow-up if the beacon issue continues.",
+      rootRequestId: manualRequestId("emp_010", "2026-04-13", "root"),
+      parentRequestId: null,
+      followUpKind: null,
+      supersededByRequestId: null,
+    },
+    {
+      id: manualRequestId("emp_010", "2026-04-13", "resubmission"),
+      employeeId: "emp_010",
+      requestType: "manual_attendance",
+      action: "clock_in",
+      date: "2026-04-13",
+      submittedAt: buildFixedSeoulDateTime("2026-04-13", "16:35:00"),
+      requestedClockInAt: buildFixedSeoulDateTime("2026-04-13", "09:08:00"),
+      requestedClockOutAt: null,
+      reason:
+        "Resubmitting after the beacon outage to keep the correction chain linked.",
+      status: "pending",
+      reviewedAt: null,
+      reviewComment: null,
+      rootRequestId: manualRequestId("emp_010", "2026-04-13", "root"),
+      parentRequestId: manualRequestId("emp_010", "2026-04-13", "root"),
+      followUpKind: "resubmission",
+      supersededByRequestId: null,
+    },
+  ]),
+);
+
+const leaveRequests = deepFreeze(
+  leaveRequestEntitySchema.array().parse([
+    {
+      id: leaveRequestId("emp_004", "2026-04-16", "root"),
+      employeeId: "emp_004",
+      requestType: "leave",
+      leaveType: "annual",
+      date: "2026-04-16",
+      startAt: null,
+      endAt: null,
+      reason: "Spring launch dry run requires a full-day absence.",
+      requestedAt: buildFixedSeoulDateTime("2026-04-13", "09:30:00"),
+      status: "approved",
+      reviewedAt: buildFixedSeoulDateTime("2026-04-14", "10:30:00"),
+      reviewComment: null,
+      rootRequestId: leaveRequestId("emp_004", "2026-04-16", "root"),
+      parentRequestId: null,
+      followUpKind: null,
+      supersededByRequestId: null,
+    },
+    {
+      id: leaveRequestId("emp_004", "2026-04-16", "change"),
+      employeeId: "emp_004",
+      requestType: "leave",
+      leaveType: "hourly",
+      date: "2026-04-16",
+      startAt: buildFixedSeoulDateTime("2026-04-16", "13:00:00"),
+      endAt: buildFixedSeoulDateTime("2026-04-16", "16:00:00"),
+      reason:
+        "Adjusting the approved leave window for the afternoon briefings.",
+      requestedAt: buildFixedSeoulDateTime("2026-04-15", "11:00:00"),
+      status: "pending",
+      reviewedAt: null,
+      reviewComment: null,
+      rootRequestId: leaveRequestId("emp_004", "2026-04-16", "root"),
+      parentRequestId: leaveRequestId("emp_004", "2026-04-16", "root"),
+      followUpKind: "change",
+      supersededByRequestId: null,
+    },
+    {
+      id: leaveRequestId("emp_006", "2026-04-17", "root"),
+      employeeId: "emp_006",
+      requestType: "leave",
+      leaveType: "annual",
+      date: "2026-04-17",
+      startAt: null,
+      endAt: null,
+      reason: "Inventory audit support is pulling coverage from the team.",
+      requestedAt: buildFixedSeoulDateTime("2026-04-13", "15:10:00"),
+      status: "pending",
+      reviewedAt: null,
+      reviewComment: null,
+      rootRequestId: leaveRequestId("emp_006", "2026-04-17", "root"),
+      parentRequestId: null,
+      followUpKind: null,
+      supersededByRequestId: null,
+    },
+    {
+      id: leaveRequestId("emp_005", "2026-04-18", "root"),
+      employeeId: "emp_005",
+      requestType: "leave",
+      leaveType: "annual",
+      date: "2026-04-18",
+      startAt: null,
+      endAt: null,
+      reason: "Planned personal leave for the full workday.",
+      requestedAt: buildFixedSeoulDateTime("2026-04-13", "16:20:00"),
+      status: "approved",
+      reviewedAt: buildFixedSeoulDateTime("2026-04-15", "09:10:00"),
+      reviewComment: null,
+      rootRequestId: leaveRequestId("emp_005", "2026-04-18", "root"),
+      parentRequestId: null,
+      followUpKind: null,
+      supersededByRequestId: null,
+    },
+    {
+      id: leaveRequestId("emp_010", "2026-04-20", "root"),
+      employeeId: "emp_010",
+      requestType: "leave",
+      leaveType: "annual",
+      date: "2026-04-20",
+      startAt: null,
+      endAt: null,
+      reason: "Family appointment on the final workday of the month window.",
+      requestedAt: buildFixedSeoulDateTime("2026-04-16", "10:05:00"),
+      status: "rejected",
+      reviewedAt: buildFixedSeoulDateTime("2026-04-18", "13:40:00"),
+      reviewComment: "Please resubmit after adjusting the staffing plan.",
+      rootRequestId: leaveRequestId("emp_010", "2026-04-20", "root"),
+      parentRequestId: null,
+      followUpKind: null,
+      supersededByRequestId: null,
+    },
+    {
+      id: leaveRequestId("emp_010", "2026-04-20", "resubmission"),
+      employeeId: "emp_010",
+      requestType: "leave",
+      leaveType: "annual",
+      date: "2026-04-20",
+      startAt: null,
+      endAt: null,
+      reason:
+        "Resubmitting the leave request with the same target date and updated note.",
+      requestedAt: buildFixedSeoulDateTime("2026-04-19", "09:25:00"),
+      status: "pending",
+      reviewedAt: null,
+      reviewComment: null,
+      rootRequestId: leaveRequestId("emp_010", "2026-04-20", "root"),
+      parentRequestId: leaveRequestId("emp_010", "2026-04-20", "root"),
+      followUpKind: "resubmission",
+      supersededByRequestId: null,
+    },
+  ]),
+);
+
+const requestReviewEvents = deepFreeze(
+  requestReviewEventEntitySchema.array().parse([
+    {
+      id: "request_review_manual_emp_007_2026-04-03",
+      requestId: manualRequestId("emp_007", "2026-04-03", "root"),
+      decision: "approve",
+      reviewComment: null,
+      reviewedAt: buildFixedSeoulDateTime("2026-04-04", "09:15:00"),
+      reviewerId: "emp_012",
+    },
+    {
+      id: "request_review_manual_emp_009_2026-04-08",
+      requestId: manualRequestId("emp_009", "2026-04-08", "root"),
+      decision: "reject",
+      reviewComment: "Please resubmit with a clearer arrival note.",
+      reviewedAt: buildFixedSeoulDateTime("2026-04-08", "14:20:00"),
+      reviewerId: "emp_012",
+    },
+    {
+      id: "request_review_manual_emp_010_2026-04-13",
+      requestId: manualRequestId("emp_010", "2026-04-13", "root"),
+      decision: "reject",
+      reviewComment: "Please submit a follow-up if the beacon issue continues.",
+      reviewedAt: buildFixedSeoulDateTime("2026-04-13", "14:00:00"),
+      reviewerId: "emp_012",
+    },
+    {
+      id: "request_review_leave_emp_004_2026-04-16",
+      requestId: leaveRequestId("emp_004", "2026-04-16", "root"),
+      decision: "approve",
+      reviewComment: null,
+      reviewedAt: buildFixedSeoulDateTime("2026-04-14", "10:30:00"),
+      reviewerId: "emp_012",
+    },
+    {
+      id: "request_review_leave_emp_005_2026-04-18",
+      requestId: leaveRequestId("emp_005", "2026-04-18", "root"),
+      decision: "approve",
+      reviewComment: null,
+      reviewedAt: buildFixedSeoulDateTime("2026-04-15", "09:10:00"),
+      reviewerId: "emp_012",
+    },
+    {
+      id: "request_review_leave_emp_010_2026-04-20",
+      requestId: leaveRequestId("emp_010", "2026-04-20", "root"),
+      decision: "reject",
+      reviewComment: "Please resubmit after adjusting the staffing plan.",
+      reviewedAt: buildFixedSeoulDateTime("2026-04-18", "13:40:00"),
+      reviewerId: "emp_012",
+    },
+  ]),
+);
+
+const companyEvents = deepFreeze(
+  companyEventEntitySchema.array().parse([
+    {
+      id: "company_event_2026-04-16_spring-launch",
+      date: "2026-04-16",
+      title: "Spring Launch Dry Run",
+    },
+    {
+      id: "company_event_2026-04-17_inventory-audit",
+      date: "2026-04-17",
+      title: "Quarterly Inventory Audit",
+    },
+  ]),
+);
+
+export const canonicalSeedWorld = deepFreeze({
+  baselineDate: fixedSeoulBaselineDate,
+  calendarWindow: fixedSeoulCalendarWindow,
+  employees,
+  expectedWorkdays,
+  attendanceAttempts,
+  attendanceRecords,
+  manualAttendanceRequests,
+  leaveRequests,
+  requestReviewEvents,
+  companyEvents,
+});
+
+export const seedScenarioAnchors = deepFreeze({
+  previousDayMissingCheckout: {
+    employeeId: "emp_001",
+    recordDate: "2026-04-10",
+    surfaceDate: "2026-04-13",
+    attendanceRecordId: attendanceRecordId("emp_001", "2026-04-10"),
+  },
+  nextDayCheckout: {
+    employeeId: "emp_002",
+    recordDate: "2026-04-14",
+    checkoutAttemptId: attendanceAttemptId(
+      "emp_002",
+      "2026-04-14",
+      "clock_out",
+      "success",
+    ),
+    closedAt: buildFixedSeoulDateTime("2026-04-15", "08:45:00"),
+  },
+  unresolvedFailedAttempt: {
+    employeeId: "emp_003",
+    date: "2026-04-16",
+    attemptId: attendanceAttemptId(
+      "emp_003",
+      "2026-04-16",
+      "clock_out",
+      "failed",
+    ),
+  },
+  companyEventSensitiveLeaveDate: {
+    employeeId: "emp_004",
+    date: "2026-04-16",
+    eventId: "company_event_2026-04-16_spring-launch",
+    activeRequestId: leaveRequestId("emp_004", "2026-04-16", "change"),
+  },
+  staffingSensitiveLeaveDate: {
+    employeeId: "emp_006",
+    date: "2026-04-17",
+    activeRequestId: leaveRequestId("emp_006", "2026-04-17", "root"),
+  },
+  leaveWorkConflict: {
+    employeeId: "emp_005",
+    date: "2026-04-18",
+    attendanceRecordId: attendanceRecordId("emp_005", "2026-04-18"),
+    leaveRequestId: leaveRequestId("emp_005", "2026-04-18", "root"),
+  },
+  manualAttendanceResubmissionChain: {
+    employeeId: "emp_009",
+    rootRequestId: manualRequestId("emp_009", "2026-04-08", "root"),
+    activeRequestId: manualRequestId("emp_009", "2026-04-08", "resubmission"),
+  },
+  pendingManualEdit: {
+    employeeId: "emp_010",
+    requestId: manualRequestId("emp_010", "2026-04-09", "root"),
+  },
+  pendingManualWithdraw: {
+    employeeId: "emp_011",
+    requestId: manualRequestId("emp_011", "2026-04-07", "root"),
+  },
+  approvedManualWriteback: {
+    employeeId: "emp_007",
+    requestId: manualRequestId("emp_007", "2026-04-03", "root"),
+    attendanceRecordId: attendanceRecordId("emp_007", "2026-04-03"),
+  },
+  reviewedNonApprovedLeaveTrail: {
+    employeeId: "emp_010",
+    reviewedRequestId: leaveRequestId("emp_010", "2026-04-20", "root"),
+    activeRequestId: leaveRequestId("emp_010", "2026-04-20", "resubmission"),
+  },
+});
+
+export type CanonicalSeedWorld = typeof canonicalSeedWorld;
+export type SeedScenarioAnchors = typeof seedScenarioAnchors;

--- a/tests/unit/seed-world.test.ts
+++ b/tests/unit/seed-world.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  attendanceAttemptEntitySchema,
+  attendanceRecordEntitySchema,
+  companyEventEntitySchema,
+  leaveRequestEntitySchema,
+  manualAttendanceRequestEntitySchema,
+  requestReviewEventEntitySchema,
+} from "@/lib/seed/entities";
+import {
+  buildFixedSeoulDateTime,
+  fixedSeoulBaselineDate,
+  fixedSeoulCalendarWindow,
+  fixedSeoulTimeZone,
+  fixedSeoulUtcOffset,
+} from "@/lib/seed/seoul-clock";
+import { canonicalSeedWorld, seedScenarioAnchors } from "@/lib/seed/world";
+
+describe("fixed Seoul seed clock", () => {
+  it("locks the deterministic Seoul baseline date and window", () => {
+    expect(fixedSeoulTimeZone).toBe("Asia/Seoul");
+    expect(fixedSeoulUtcOffset).toBe("+09:00");
+    expect(fixedSeoulBaselineDate).toBe("2026-04-13");
+    expect(fixedSeoulCalendarWindow).toEqual({
+      start: "2026-03-23",
+      end: "2026-04-20",
+    });
+    expect(buildFixedSeoulDateTime("2026-04-15", "08:45:00")).toBe(
+      "2026-04-15T08:45:00+09:00",
+    );
+  });
+});
+
+describe("canonical seed world", () => {
+  it("seeds one deterministic canonical world with 12 employees", () => {
+    expect(canonicalSeedWorld.employees).toHaveLength(12);
+    expect(canonicalSeedWorld.employees[0]).toEqual({
+      id: "emp_001",
+      name: "Minji Park",
+      department: "Operations",
+      role: "employee",
+    });
+    expect(canonicalSeedWorld.employees.at(-1)).toEqual({
+      id: "emp_012",
+      name: "Jiwon Han",
+      department: "People",
+      role: "admin",
+    });
+  });
+
+  it("covers the required seed-world scenario anchors", () => {
+    expect(seedScenarioAnchors.previousDayMissingCheckout).toEqual({
+      employeeId: "emp_001",
+      recordDate: "2026-04-10",
+      surfaceDate: "2026-04-13",
+      attendanceRecordId: "attendance_record_emp_001_2026-04-10",
+    });
+    expect(seedScenarioAnchors.nextDayCheckout).toEqual({
+      employeeId: "emp_002",
+      recordDate: "2026-04-14",
+      checkoutAttemptId: "attendance_attempt_emp_002_2026-04-14_clock_out",
+      closedAt: "2026-04-15T08:45:00+09:00",
+    });
+    expect(seedScenarioAnchors.unresolvedFailedAttempt).toEqual({
+      employeeId: "emp_003",
+      date: "2026-04-16",
+      attemptId: "attendance_attempt_emp_003_2026-04-16_clock_out_failed",
+    });
+    expect(seedScenarioAnchors.companyEventSensitiveLeaveDate).toEqual({
+      employeeId: "emp_004",
+      date: "2026-04-16",
+      eventId: "company_event_2026-04-16_spring-launch",
+      activeRequestId: "leave_request_emp_004_2026-04-16_change",
+    });
+    expect(seedScenarioAnchors.staffingSensitiveLeaveDate).toEqual({
+      employeeId: "emp_006",
+      date: "2026-04-17",
+      activeRequestId: "leave_request_emp_006_2026-04-17_root",
+    });
+    expect(seedScenarioAnchors.leaveWorkConflict).toEqual({
+      employeeId: "emp_005",
+      date: "2026-04-18",
+      attendanceRecordId: "attendance_record_emp_005_2026-04-18",
+      leaveRequestId: "leave_request_emp_005_2026-04-18_root",
+    });
+    expect(seedScenarioAnchors.manualAttendanceResubmissionChain).toEqual({
+      employeeId: "emp_009",
+      rootRequestId: "manual_request_emp_009_2026-04-08_root",
+      activeRequestId: "manual_request_emp_009_2026-04-08_resubmission",
+    });
+    expect(seedScenarioAnchors.pendingManualEdit).toEqual({
+      employeeId: "emp_010",
+      requestId: "manual_request_emp_010_2026-04-09_root",
+    });
+    expect(seedScenarioAnchors.pendingManualWithdraw).toEqual({
+      employeeId: "emp_011",
+      requestId: "manual_request_emp_011_2026-04-07_root",
+    });
+    expect(seedScenarioAnchors.approvedManualWriteback).toEqual({
+      employeeId: "emp_007",
+      requestId: "manual_request_emp_007_2026-04-03_root",
+      attendanceRecordId: "attendance_record_emp_007_2026-04-03",
+    });
+    expect(seedScenarioAnchors.reviewedNonApprovedLeaveTrail).toEqual({
+      employeeId: "emp_010",
+      reviewedRequestId: "leave_request_emp_010_2026-04-20_root",
+      activeRequestId: "leave_request_emp_010_2026-04-20_resubmission",
+    });
+  });
+
+  it("links approved manual writeback facts back into the canonical attendance record", () => {
+    expect(
+      canonicalSeedWorld.attendanceRecords.find(
+        (record) =>
+          record.id ===
+          seedScenarioAnchors.approvedManualWriteback.attendanceRecordId,
+      ),
+    ).toMatchObject({
+      employeeId: "emp_007",
+      date: "2026-04-03",
+      clockOutSource: "manual",
+      manualRequestId: "manual_request_emp_007_2026-04-03_root",
+    });
+  });
+
+  it("keeps seeded leave anchors on canonical workdays and stores leave request timestamps", () => {
+    expect(
+      canonicalSeedWorld.expectedWorkdays.find(
+        (workday) =>
+          workday.employeeId === "emp_005" && workday.date === "2026-04-18",
+      ),
+    ).toMatchObject({
+      employeeId: "emp_005",
+      date: "2026-04-18",
+      isWorkday: true,
+      expectedClockInAt: "2026-04-18T09:00:00+09:00",
+      expectedClockOutAt: "2026-04-18T18:00:00+09:00",
+    });
+
+    expect(
+      canonicalSeedWorld.leaveRequests.find(
+        (request) => request.id === "leave_request_emp_004_2026-04-16_root",
+      ),
+    ).toMatchObject({
+      requestedAt: "2026-04-13T09:30:00+09:00",
+    });
+  });
+
+  it("keeps seeded company events read-only", () => {
+    expect(canonicalSeedWorld.companyEvents).toHaveLength(2);
+    expect(canonicalSeedWorld.companyEvents).toEqual([
+      {
+        id: "company_event_2026-04-16_spring-launch",
+        date: "2026-04-16",
+        title: "Spring Launch Dry Run",
+      },
+      {
+        id: "company_event_2026-04-17_inventory-audit",
+        date: "2026-04-17",
+        title: "Quarterly Inventory Audit",
+      },
+    ]);
+    expect(Object.isFrozen(canonicalSeedWorld.companyEvents)).toBe(true);
+    expect(Object.isFrozen(canonicalSeedWorld.companyEvents[0])).toBe(true);
+    expect(() => {
+      (canonicalSeedWorld.companyEvents as Array<{ title: string }>)[0].title =
+        "Mutated";
+    }).toThrow();
+  });
+
+  it("rejects canonical entity samples that violate promoted enum contracts", () => {
+    expect(() =>
+      attendanceAttemptEntitySchema.parse({
+        id: "attempt_invalid",
+        employeeId: "emp_001",
+        date: "2026-04-13",
+        action: "clock_break",
+        attemptedAt: "2026-04-13T09:00:00+09:00",
+        status: "success",
+        failureReason: null,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      attendanceRecordEntitySchema.parse({
+        id: "record_invalid",
+        employeeId: "emp_001",
+        date: "2026-04-13",
+        clockInAt: "2026-04-13T09:00:00+09:00",
+        clockInSource: "app",
+        clockOutAt: null,
+        clockOutSource: null,
+        workMinutes: null,
+        manualRequestId: null,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      leaveRequestEntitySchema.parse({
+        id: "leave_invalid",
+        employeeId: "emp_001",
+        requestType: "leave",
+        leaveType: "sick",
+        date: "2026-04-16",
+        startAt: null,
+        endAt: null,
+        reason: "Invalid leave type",
+        status: "pending",
+        requestedAt: "2026-04-13T10:00:00+09:00",
+        reviewedAt: null,
+        reviewComment: null,
+        rootRequestId: "leave_invalid",
+        parentRequestId: null,
+        followUpKind: null,
+        supersededByRequestId: null,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      manualAttendanceRequestEntitySchema.parse({
+        id: "manual_invalid",
+        employeeId: "emp_001",
+        requestType: "manual_attendance",
+        action: "clock_pause",
+        date: "2026-04-13",
+        submittedAt: "2026-04-13T11:00:00+09:00",
+        requestedClockInAt: "2026-04-13T09:15:00+09:00",
+        requestedClockOutAt: null,
+        reason: "Invalid manual action",
+        status: "pending",
+        reviewedAt: null,
+        reviewComment: null,
+        rootRequestId: "manual_invalid",
+        parentRequestId: null,
+        followUpKind: null,
+        supersededByRequestId: null,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      manualAttendanceRequestEntitySchema.parse({
+        id: "manual_follow_up_invalid",
+        employeeId: "emp_001",
+        requestType: "manual_attendance",
+        action: "clock_in",
+        date: "2026-04-13",
+        submittedAt: "2026-04-13T11:00:00+09:00",
+        requestedClockInAt: "2026-04-13T09:15:00+09:00",
+        requestedClockOutAt: null,
+        reason: "Invalid manual follow-up kind",
+        status: "pending",
+        reviewedAt: null,
+        reviewComment: null,
+        rootRequestId: "manual_follow_up_invalid_root",
+        parentRequestId: "manual_follow_up_invalid_root",
+        followUpKind: "change",
+        supersededByRequestId: null,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      requestReviewEventEntitySchema.parse({
+        id: "review_invalid",
+        requestId: "leave_request_emp_004_2026-04-16_root",
+        decision: "revise",
+        reviewComment: "Invalid decision",
+        reviewedAt: "2026-04-13T13:00:00+09:00",
+        reviewerId: "emp_012",
+      }),
+    ).toThrow();
+
+    expect(() =>
+      companyEventEntitySchema.parse({
+        id: "event_invalid",
+        date: "2026-04-16",
+        title: "",
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- This PR implements `#84` as the raw seed prerequisite layer that sits below the future repository/query work in `#28`.
- It adds one fixed `Asia/Seoul` seed clock, one canonical fact-first seed entity surface, one deterministic raw seed world, and one frozen scenario-anchor map.
- It intentionally does **not** implement repository/query helpers, Route Handlers, page behavior, or derived projection builders.

## Stacking Context
- This PR is intentionally stacked on top of `#85` because `#84` depends on the runtime contract alignment work from `#83`.
- Base branch for this PR is `codex/review-83-runtime-contract-alignment`, not `main`.
- After `#85` merges, this PR should be retargeted to `main`.

## Issue Context And Discussion
- Issue `#84` was explicitly narrowed to `fixed Seoul clock + canonical base seed entities + scenario anchors`.
- The issue discussion also explicitly pushed repository/query helpers out to `#28`.
- Company events were kept as read-only seeded inputs only.
- The resulting boundary is:
  - `#83` owns contract vocabulary and runtime schema alignment
  - `#84` owns the fixed clock and canonical raw seed world
  - `#28` owns repository/query/projection logic

## What Changed
- Added a fixed Seoul clock module under `lib/seed/` with:
  - timezone `Asia/Seoul`
  - baseline date `2026-04-13`
  - deterministic seed window `2026-03-23` through `2026-04-20`
  - `+09:00` datetime construction helper
- Added canonical fact-first seed entity schemas and types for:
  - `Employee`
  - `ExpectedWorkday`
  - `AttendanceAttempt`
  - `AttendanceRecord`
  - `LeaveRequest`
  - `ManualAttendanceRequest`
  - `RequestReviewEvent`
  - `CompanyEvent`
- Added one deterministic canonical seed world with:
  - exactly 12 fixed employees
  - canonical raw attendance, request, and company-event facts
  - frozen read-only company-event inputs
  - frozen scenario anchors for downstream repository and test consumers
- Added unit coverage for:
  - fixed Seoul clock constants
  - deterministic 12-employee world
  - required scenario anchors
  - approved manual writeback to `AttendanceRecord.manualRequestId`
  - read-only company-event inputs
  - invalid canonical entity samples against promoted enum rules

## Key Decisions
- Kept the seed layer fact-first and did not encode projection-only outputs such as `active*`, `effective*`, `governingReviewComment`, `nextAction`, `leaveConflict`, summary counts, or queue filters as canonical truth.
- Kept `LeaveCoverage` derived from approved leave instead of introducing it as a mutable canonical workflow entity.
- Kept manual-attendance follow-ups restricted to `resubmission`.
- Kept approved manual-attendance requests out of post-approval `change` / `cancel` flows.
- Treated company events as read-only seeded inputs only.
- Treated `2026-04-18` as a seeded operational workday so the required leave-work conflict anchor remains representable in the canonical seed world.

## Required Scenario Coverage Included
- `2026-04-13` previous-day missing checkout anchor
- `2026-04-15` next-day checkout before `09:00`
- unresolved failed attendance attempt after baseline
- leave-work conflict on `2026-04-18`
- company-event-overlapping leave on `2026-04-16`
- staffing-sensitive full-day leave case on `2026-04-17`
- manual-attendance root + reviewed outcome + linked resubmission
- pending manual edit case
- pending manual withdraw case
- approved manual writeback into canonical attendance record
- leave chain with live follow-up
- reviewed non-approved leave trail that remains representable for later follow-up handling

## Out Of Scope
- repository/query layer from `#28`
- selectors, mutation helpers, projection builders
- Route Handler or page behavior
- browser or integration interception work from `#38`
- company-event mutation
- manager-driven reversal of approved requests
- approved manual-attendance rollback, change, or cancel flow

## Validation
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`

Refs #84
