### PR TITLE
fix(admin-attendance): restore recovered dashboard flow

### DIFF
--- a/app/(erp)/(admin)/admin/attendance/_components/admin-attendance-history-view.tsx
+++ b/app/(erp)/(admin)/admin/attendance/_components/admin-attendance-history-view.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Empty,
   EmptyDescription,
@@ -7,6 +16,7 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
 import {
   Table,
   TableBody,
@@ -16,13 +26,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import type { AdminAttendanceListResponse } from "@/lib/contracts/admin-attendance";
-import { fixedSeoulBaselineDate } from "@/lib/seed/seoul-clock";
+import { cn } from "@/lib/utils";
 
-import {
-  formatMinutesLabel,
-  formatTimeLabel,
-  getHistoryDisplayStatusLabel,
-} from "../_lib/formatting";
+import { formatMinutesLabel, formatTimeLabel } from "../_lib/formatting";
 
 type AdminAttendanceHistoryViewProps = {
   from: string;
@@ -34,6 +40,286 @@ type AdminAttendanceHistoryViewProps = {
   to: string;
 };
 
+type HistoryRecord = AdminAttendanceListResponse["records"][number];
+
+type HistoryStatusChip = Readonly<{
+  className: string;
+  label: string;
+}>;
+
+type HistorySummary = Readonly<{
+  absentCount: number;
+  correctionNeededCount: number;
+  earlyLeaveCount: number;
+  exceptionalCount: number;
+  lateCount: number;
+  leaveCoverageCount: number;
+  nonWorkdayCount: number;
+  totalCount: number;
+}>;
+
+function getExpectedWindowLabel(record: HistoryRecord) {
+  if (
+    !record.expectedWorkday.isWorkday &&
+    record.expectedWorkday.leaveCoverage === null
+  ) {
+    return "휴일";
+  }
+
+  if (
+    record.expectedWorkday.adjustedClockInAt === null &&
+    record.expectedWorkday.adjustedClockOutAt === null
+  ) {
+    return "휴가 반영";
+  }
+
+  if (
+    record.expectedWorkday.adjustedClockInAt === null ||
+    record.expectedWorkday.adjustedClockOutAt === null
+  ) {
+    return "-";
+  }
+
+  return `${formatTimeLabel(record.expectedWorkday.adjustedClockInAt)} ~ ${formatTimeLabel(record.expectedWorkday.adjustedClockOutAt)}`;
+}
+
+function getHistoryStatusChips(record: HistoryRecord) {
+  const chips: HistoryStatusChip[] = [];
+  const exceptions = new Set(record.display.activeExceptions);
+  const hasDangerousException =
+    exceptions.has("attempt_failed") ||
+    exceptions.has("not_checked_in") ||
+    exceptions.has("absent") ||
+    exceptions.has("previous_day_checkout_missing") ||
+    exceptions.has("leave_work_conflict") ||
+    exceptions.has("manual_request_pending") ||
+    exceptions.has("manual_request_rejected");
+  const hasWarningFlag =
+    record.display.flags.includes("late") ||
+    record.display.flags.includes("early_leave");
+
+  if (hasDangerousException) {
+    chips.push({
+      className:
+        "border-status-danger/20 bg-status-danger-soft text-status-danger",
+      label: "정정 필요",
+    });
+  }
+
+  if (exceptions.has("absent")) {
+    chips.push({
+      className:
+        "border-status-danger/20 bg-status-danger-soft text-status-danger",
+      label: "결근",
+    });
+  }
+
+  if (record.display.flags.includes("late")) {
+    chips.push({
+      className:
+        "border-status-warning/20 bg-status-warning-soft text-status-warning",
+      label: "지각",
+    });
+  }
+
+  if (record.display.flags.includes("early_leave")) {
+    chips.push({
+      className:
+        "border-status-warning/20 bg-status-warning-soft text-status-warning",
+      label: "조퇴",
+    });
+  }
+
+  if (chips.length === 0) {
+    chips.push({
+      className:
+        "border-status-success/20 bg-status-success-soft text-status-success",
+      label: "정상",
+    });
+  }
+
+  return {
+    chips,
+    hasDangerousException,
+    hasWarningFlag,
+  };
+}
+
+function getHistorySummaryLabel(record: HistoryRecord) {
+  if (
+    record.display.activeExceptions.includes("previous_day_checkout_missing")
+  ) {
+    return "전날 미퇴근";
+  }
+
+  if (record.display.activeExceptions.includes("attempt_failed")) {
+    return "시도 실패";
+  }
+
+  if (record.display.activeExceptions.includes("manual_request_pending")) {
+    return "정정 요청 검토 중";
+  }
+
+  if (record.display.activeExceptions.includes("manual_request_rejected")) {
+    return "정정 요청 반려";
+  }
+
+  if (record.display.activeExceptions.includes("absent")) {
+    return "결근";
+  }
+
+  if (record.display.activeExceptions.includes("leave_work_conflict")) {
+    return "휴가·출결 충돌";
+  }
+
+  if (record.display.activeExceptions.includes("not_checked_in")) {
+    return "출근 기록 없음";
+  }
+
+  if (
+    record.display.flags.includes("late") &&
+    record.display.flags.includes("early_leave")
+  ) {
+    return "지각 · 조퇴";
+  }
+
+  if (record.display.flags.includes("late")) {
+    return "지각";
+  }
+
+  if (record.display.flags.includes("early_leave")) {
+    return "조퇴";
+  }
+
+  if (record.display.phase === "checked_out") {
+    return "근무 완료";
+  }
+
+  if (record.display.phase === "working") {
+    return "근무 중";
+  }
+
+  if (record.display.phase === "non_workday") {
+    return "비근무일";
+  }
+
+  return "출근 전";
+}
+
+function getRowToneClass(record: HistoryRecord) {
+  const status = getHistoryStatusChips(record);
+
+  if (status.hasDangerousException) {
+    return "bg-status-danger-soft/35 hover:bg-status-danger-soft/50";
+  }
+
+  if (status.hasWarningFlag) {
+    return "bg-status-warning-soft/24 hover:bg-status-warning-soft/38";
+  }
+
+  return null;
+}
+
+function buildHistorySummary(records: HistoryRecord[]): HistorySummary {
+  return records.reduce<HistorySummary>(
+    (summary, record) => {
+      const status = getHistoryStatusChips(record);
+
+      return {
+        absentCount:
+          summary.absentCount +
+          (status.chips.some((chip) => chip.label === "결근") ? 1 : 0),
+        correctionNeededCount:
+          summary.correctionNeededCount +
+          (status.chips.some((chip) => chip.label === "정정 필요") ? 1 : 0),
+        earlyLeaveCount:
+          summary.earlyLeaveCount +
+          (status.chips.some((chip) => chip.label === "조퇴") ? 1 : 0),
+        exceptionalCount:
+          summary.exceptionalCount +
+          (status.hasDangerousException || status.hasWarningFlag ? 1 : 0),
+        lateCount:
+          summary.lateCount +
+          (status.chips.some((chip) => chip.label === "지각") ? 1 : 0),
+        leaveCoverageCount:
+          summary.leaveCoverageCount +
+          (record.expectedWorkday.leaveCoverage !== null ? 1 : 0),
+        nonWorkdayCount:
+          summary.nonWorkdayCount + (record.expectedWorkday.isWorkday ? 0 : 1),
+        totalCount: summary.totalCount + 1,
+      };
+    },
+    {
+      absentCount: 0,
+      correctionNeededCount: 0,
+      earlyLeaveCount: 0,
+      exceptionalCount: 0,
+      lateCount: 0,
+      leaveCoverageCount: 0,
+      nonWorkdayCount: 0,
+      totalCount: 0,
+    },
+  );
+}
+
+function StatusChip({
+  className,
+  label,
+}: Readonly<{
+  className: string;
+  label: string;
+}>) {
+  return (
+    <Badge
+      className={cn(
+        "h-6 rounded-full px-2.5 text-[11px] font-medium shadow-none",
+        className,
+      )}
+      variant="ghost"
+    >
+      {label}
+    </Badge>
+  );
+}
+
+function MetricTile({
+  className,
+  label,
+  value,
+}: Readonly<{
+  className?: string;
+  label: string;
+  value: string;
+}>) {
+  return (
+    <div
+      className={cn(
+        "rounded-[14px] border border-border bg-surface-subtle/60 p-4",
+        className,
+      )}
+    >
+      <p className="text-[11px] font-medium tracking-[0.08em] text-muted-foreground uppercase">
+        {label}
+      </p>
+      <p className="mt-2 text-[24px] font-semibold tracking-[-0.04em] text-foreground tabular-nums">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function getNameFilterLabel(name?: string) {
+  return name === undefined || name.trim().length === 0 ? "전체" : name.trim();
+}
+
+function formatLedgerTimeLabel(value: string | null) {
+  return value === null ? "-" : formatTimeLabel(value);
+}
+
+function formatLedgerMinutesLabel(value: number | null) {
+  return value === null ? "-" : formatMinutesLabel(value);
+}
+
 export function AdminAttendanceHistoryView({
   from,
   name,
@@ -43,120 +329,281 @@ export function AdminAttendanceHistoryView({
   response,
   to,
 }: AdminAttendanceHistoryViewProps) {
+  const records = [...response.records].sort((left, right) =>
+    right.date.localeCompare(left.date),
+  );
+  const summary = buildHistorySummary(records);
+  const nameFilterLabel = getNameFilterLabel(name);
+
   return (
-    <div className="flex flex-col gap-4">
-      <section
-        aria-label="이력 필터"
-        className="grid gap-3 rounded-[16px] border border-border bg-card p-6 md:grid-cols-3"
-      >
-        <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
-          이름
-          <Input
-            autoComplete="off"
-            value={name ?? ""}
-            name="name"
-            onChange={(event) => onNameChange(event.target.value)}
-            placeholder="이름으로 찾기"
-          />
-        </label>
+    <div className="flex flex-col gap-6">
+      <section className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>근태 이력을 한눈에 보고 있어요</CardTitle>
+            <CardDescription>
+              이름과 날짜 범위를 좁히면 필요한 기록만 빠르게 비교할 수 있어요
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="flex flex-wrap gap-2">
+              <Badge
+                className="border-border bg-white text-secondary"
+                variant="outline"
+              >
+                기간 {from} ~ {to}
+              </Badge>
+              <Badge
+                className="border-border bg-white text-secondary"
+                variant="outline"
+              >
+                이름 {nameFilterLabel}
+              </Badge>
+              <Badge
+                className="border-status-danger/20 bg-status-danger-soft text-status-danger"
+                variant="ghost"
+              >
+                확인 필요 {summary.exceptionalCount}건
+              </Badge>
+            </div>
 
-        <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
-          시작일
-          <Input
-            autoComplete="off"
-            value={from}
-            name="from"
-            onChange={(event) => onFromChange(event.target.value)}
-            type="date"
-          />
-        </label>
+            <Separator />
 
-        <label className="flex flex-col gap-2 text-sm font-medium text-foreground">
-          종료일
-          <Input
-            autoComplete="off"
-            value={to}
-            name="to"
-            onChange={(event) => onToChange(event.target.value)}
-            type="date"
-          />
-        </label>
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              <MetricTile
+                label="표시된 기록"
+                value={`${summary.totalCount}건`}
+              />
+              <MetricTile
+                label="정정 필요"
+                value={`${summary.correctionNeededCount}건`}
+              />
+              <MetricTile label="지각" value={`${summary.lateCount}건`} />
+              <MetricTile
+                label="조퇴·결근"
+                value={`${summary.earlyLeaveCount + summary.absentCount}건`}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>운영 요약</CardTitle>
+            <CardDescription>
+              현재 목록에서 눈에 띄는 상태만 모았어요
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+            <MetricTile
+              className="bg-primary/5"
+              label="운영 확인"
+              value={`${summary.exceptionalCount}건`}
+            />
+            <MetricTile
+              label="휴가 반영"
+              value={`${summary.leaveCoverageCount}건`}
+            />
+            <MetricTile label="휴일" value={`${summary.nonWorkdayCount}건`} />
+            <MetricTile
+              label="조퇴 또는 결근"
+              value={`${summary.earlyLeaveCount + summary.absentCount}건`}
+            />
+          </CardContent>
+        </Card>
       </section>
 
-      {response.records.length === 0 ? (
-        <Empty className="border border-border bg-card">
-          <EmptyHeader>
-            <EmptyTitle>조건에 맞는 근태 이력이 없어요.</EmptyTitle>
-            <EmptyDescription>
-              이름이나 날짜 범위를 바꾸면 다른 기록을 바로 확인할 수 있어요.
-            </EmptyDescription>
-          </EmptyHeader>
-        </Empty>
-      ) : (
-        <section className="overflow-hidden rounded-[16px] border border-border bg-card">
-          <div className="border-b border-border/80 px-6 py-5">
-            <h2 className="text-xl font-medium tracking-[-0.03em] text-foreground">
-              근태 이력
-            </h2>
-            <p className="text-sm leading-6 text-secondary">
-              조건에 맞는 기간과 팀원을 좁혀서 운영 이력을 확인해요.
-            </p>
-          </div>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>날짜</TableHead>
-                <TableHead>이름</TableHead>
-                <TableHead>기준 시간</TableHead>
-                <TableHead>출근</TableHead>
-                <TableHead>퇴근</TableHead>
-                <TableHead>근무 시간</TableHead>
-                <TableHead>상태</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {response.records.map((record) => (
-                <TableRow key={`${record.date}-${record.employee.id}`}>
-                  <TableCell>{record.date}</TableCell>
-                  <TableCell>
-                    <div className="flex flex-col gap-0.5">
-                      <span className="font-medium text-foreground">
-                        {record.employee.name}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {record.employee.department}
-                      </span>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    {record.expectedWorkday.adjustedClockInAt === null &&
-                    record.expectedWorkday.adjustedClockOutAt === null
-                      ? "휴가 반영"
-                      : `${formatTimeLabel(record.expectedWorkday.adjustedClockInAt)} ~ ${formatTimeLabel(record.expectedWorkday.adjustedClockOutAt)}`}
-                  </TableCell>
-                  <TableCell>
-                    {formatTimeLabel(record.record?.clockInAt ?? null)}
-                  </TableCell>
-                  <TableCell>
-                    {formatTimeLabel(record.record?.clockOutAt ?? null)}
-                  </TableCell>
-                  <TableCell>
-                    {formatMinutesLabel(record.record?.workMinutes ?? null)}
-                  </TableCell>
-                  <TableCell>
-                    {record.date < fixedSeoulBaselineDate &&
-                    record.record !== null &&
-                    record.record.clockInAt !== null &&
-                    record.record.clockOutAt === null
-                      ? "퇴근 누락"
-                      : getHistoryDisplayStatusLabel(record.display)}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </section>
-      )}
+      <section className="grid gap-4 xl:grid-cols-[320px_minmax(0,1fr)] xl:items-start">
+        <Card className="self-start">
+          <CardHeader>
+            <CardTitle>필터</CardTitle>
+            <CardDescription>
+              이름과 날짜 범위를 바꿔서 이력을 좁혀요
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <label
+              className="flex flex-col gap-2 text-sm font-medium text-foreground"
+              htmlFor="admin-attendance-history-name"
+            >
+              이름
+              <Input
+                autoComplete="off"
+                id="admin-attendance-history-name"
+                name="name"
+                onChange={(event) => onNameChange(event.target.value)}
+                placeholder="이름으로 찾아요…"
+                type="search"
+                value={name ?? ""}
+              />
+            </label>
+
+            <Separator />
+
+            <div className="grid gap-4">
+              <label
+                className="flex flex-col gap-2 text-sm font-medium text-foreground"
+                htmlFor="admin-attendance-history-from"
+              >
+                시작일
+                <Input
+                  autoComplete="off"
+                  id="admin-attendance-history-from"
+                  name="from"
+                  onChange={(event) => onFromChange(event.target.value)}
+                  type="date"
+                  value={from}
+                />
+              </label>
+
+              <label
+                className="flex flex-col gap-2 text-sm font-medium text-foreground"
+                htmlFor="admin-attendance-history-to"
+              >
+                종료일
+                <Input
+                  autoComplete="off"
+                  id="admin-attendance-history-to"
+                  name="to"
+                  onChange={(event) => onToChange(event.target.value)}
+                  type="date"
+                  value={to}
+                />
+              </label>
+            </div>
+
+            <div className="rounded-[14px] border border-border bg-surface-subtle/60 p-4">
+              <p className="text-[11px] font-medium tracking-[0.08em] text-muted-foreground uppercase">
+                현재 조건
+              </p>
+              <p className="mt-2 text-sm font-medium text-foreground">
+                {from} ~ {to}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-secondary">
+                {summary.totalCount}건 중 확인이 필요한 근태는{" "}
+                {summary.exceptionalCount}건이에요
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {records.length === 0 ? (
+          <Empty className="border border-border bg-card">
+            <EmptyHeader>
+              <EmptyTitle>
+                조건에 맞는 근태 이력이 없어요
+                <span className="sr-only">.</span>
+              </EmptyTitle>
+              <EmptyDescription>
+                이름이나 날짜 범위를 바꾸면 다른 기록을 바로 확인할 수 있어요
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <Card>
+            <CardHeader>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="flex flex-col gap-1">
+                  <CardTitle>근태 이력</CardTitle>
+                  <CardDescription>
+                    최신 기록부터 보고 필요한 날짜만 다시 살펴봐요
+                  </CardDescription>
+                </div>
+                <Badge
+                  className="border-border bg-white text-secondary"
+                  variant="outline"
+                >
+                  {summary.totalCount}건
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="p-0">
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>날짜</TableHead>
+                      <TableHead>이름</TableHead>
+                      <TableHead>기준 시간</TableHead>
+                      <TableHead>출근</TableHead>
+                      <TableHead>퇴근</TableHead>
+                      <TableHead>근무 시간</TableHead>
+                      <TableHead>상태</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {records.map((record) => {
+                      const status = getHistoryStatusChips(record);
+                      const rowToneClass = getRowToneClass(record);
+
+                      return (
+                        <TableRow
+                          key={`${record.date}-${record.employee.id}`}
+                          className={cn(rowToneClass)}
+                        >
+                          <TableCell className="font-medium text-foreground tabular-nums">
+                            {record.date}
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex flex-col gap-0.5">
+                              <span className="font-medium text-foreground">
+                                {record.employee.name}
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                {record.employee.department}
+                              </span>
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-foreground">
+                            {getExpectedWindowLabel(record)}
+                          </TableCell>
+                          <TableCell className="whitespace-nowrap text-foreground tabular-nums">
+                            {formatLedgerTimeLabel(
+                              record.record?.clockInAt ?? null,
+                            )}
+                          </TableCell>
+                          <TableCell className="whitespace-nowrap text-foreground tabular-nums">
+                            {formatLedgerTimeLabel(
+                              record.record?.clockOutAt ?? null,
+                            )}
+                          </TableCell>
+                          <TableCell className="whitespace-nowrap text-foreground tabular-nums">
+                            {formatLedgerMinutesLabel(
+                              record.record?.workMinutes ?? null,
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex flex-col gap-2">
+                              <div className="flex flex-wrap gap-2">
+                                {status.chips.map((chip) => (
+                                  <StatusChip
+                                    key={`${record.date}-${record.employee.id}-${chip.label}`}
+                                    className={chip.className}
+                                    label={chip.label}
+                                  />
+                                ))}
+                              </div>
+                              <span className="text-xs leading-5 text-secondary">
+                                {getHistorySummaryLabel(record)}
+                              </span>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col items-start gap-1 text-[11px] text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+              <span>최근 {summary.totalCount}건을 표시하고 있어요</span>
+              <span>
+                {response.from} ~ {response.to}
+              </span>
+            </CardFooter>
+          </Card>
+        )}
+      </section>
     </div>
   );
 }

--- a/app/(erp)/(admin)/admin/attendance/_components/admin-attendance-summary-cards.tsx
+++ b/app/(erp)/(admin)/admin/attendance/_components/admin-attendance-summary-cards.tsx
@@ -1,80 +1,118 @@
-import {
-  CalendarDaysIcon,
-  Clock3Icon,
-  FileWarningIcon,
-  TriangleAlertIcon,
-} from "lucide-react";
-
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
 import type { AdminAttendanceTodayResponse } from "@/lib/contracts/admin-attendance";
 
-const summaryCards: Array<{
-  accentClassName: string;
-  icon: typeof Clock3Icon;
-  key: keyof AdminAttendanceTodayResponse["summary"];
+type TodayItem = AdminAttendanceTodayResponse["items"][number];
+
+type SummaryCard = Readonly<{
+  description: string;
+  key: string;
   title: string;
-}> = [
-  {
-    key: "checkedInCount",
-    title: "출근 완료",
-    icon: Clock3Icon,
-    accentClassName: "bg-status-success-soft text-status-success",
-  },
-  {
-    key: "notCheckedInCount",
-    title: "출근 전",
-    icon: TriangleAlertIcon,
-    accentClassName: "bg-status-danger-soft text-status-danger",
-  },
-  {
-    key: "lateCount",
-    title: "지각",
-    icon: TriangleAlertIcon,
-    accentClassName: "bg-status-warning-soft text-status-warning",
-  },
-  {
-    key: "onLeaveCount",
-    title: "휴가",
-    icon: CalendarDaysIcon,
-    accentClassName: "bg-status-info-soft text-status-info",
-  },
-  {
-    key: "failedAttemptCount",
-    title: "출결 시도 실패",
-    icon: FileWarningIcon,
-    accentClassName: "bg-status-warning-soft text-status-warning",
-  },
-];
+  value: number;
+}>;
 
 type AdminAttendanceSummaryCardsProps = {
-  summary: AdminAttendanceTodayResponse["summary"];
+  items: TodayItem[];
 };
 
+function buildSummaryCards(items: TodayItem[]): SummaryCard[] {
+  return [
+    {
+      key: "working",
+      title: "근무중",
+      description: "지금 근무하고 있는 인원",
+      value: items.filter((item) => item.display.phase === "working").length,
+    },
+    {
+      key: "before-check-in",
+      title: "출근 전",
+      description: "아직 출근 전인 인원",
+      value: items.filter((item) => item.display.phase === "before_check_in")
+        .length,
+    },
+    {
+      key: "late",
+      title: "지각",
+      description: "지각 플래그가 있는 인원",
+      value: items.filter((item) => item.display.flags.includes("late")).length,
+    },
+    {
+      key: "early-leave",
+      title: "조퇴",
+      description: "조퇴 플래그가 있는 인원",
+      value: items.filter((item) => item.display.flags.includes("early_leave"))
+        .length,
+    },
+    {
+      key: "annual",
+      title: "연차",
+      description: "연차가 반영된 인원",
+      value: items.filter(
+        (item) => item.expectedWorkday.leaveCoverage?.leaveType === "annual",
+      ).length,
+    },
+    {
+      key: "half-day",
+      title: "반차",
+      description: "반차가 반영된 인원",
+      value: items.filter((item) => {
+        const leaveType = item.expectedWorkday.leaveCoverage?.leaveType;
+        return leaveType === "half_am" || leaveType === "half_pm";
+      }).length,
+    },
+    {
+      key: "hourly",
+      title: "시간차",
+      description: "시간차가 반영된 인원",
+      value: items.filter(
+        (item) => item.expectedWorkday.leaveCoverage?.leaveType === "hourly",
+      ).length,
+    },
+  ];
+}
+
 export function AdminAttendanceSummaryCards({
-  summary,
+  items,
 }: AdminAttendanceSummaryCardsProps) {
+  const cards = buildSummaryCards(items);
+
   return (
-    <section
-      aria-label="오늘 요약"
-      className="grid gap-4 md:grid-cols-2 xl:grid-cols-3"
-    >
-      {summaryCards.map((card) => (
-        <Card key={card.key} size="sm">
-          <CardHeader className="gap-3">
-            <div
-              className={`flex size-9 items-center justify-center rounded-full ${card.accentClassName}`}
+    <section aria-label="오늘 요약" className="flex flex-col gap-3">
+      <div className="flex items-end justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-sm font-medium text-foreground">오늘 요약</h2>
+          <p className="text-sm leading-6 text-muted-foreground">
+            검색 결과 기준으로 현재 상태를 바로 비교해요
+          </p>
+        </div>
+        <Badge variant="outline">{items.length}명</Badge>
+      </div>
+
+      <div className="-mx-1 overflow-x-auto px-1">
+        <div className="flex min-w-max gap-3">
+          {cards.map((card) => (
+            <Card
+              key={card.key}
+              size="sm"
+              className="w-[156px] shrink-0 border-border/80 bg-card/95"
             >
-              <card.icon aria-hidden="true" className="size-4" />
-            </div>
-            <CardTitle>{card.title}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-[32px] font-bold tracking-[-0.04em] text-foreground">
-              {summary[card.key]}
-            </p>
-          </CardContent>
-        </Card>
-      ))}
+              <CardContent className="flex flex-col gap-3 p-4">
+                <div className="flex flex-col gap-1">
+                  <p className="text-sm font-medium text-foreground">
+                    {card.title}
+                  </p>
+                  <p className="text-xs leading-5 text-muted-foreground">
+                    {card.description}
+                  </p>
+                </div>
+                <p className="text-[28px] font-bold tracking-[-0.04em] text-foreground tabular-nums">
+                  {card.value}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
     </section>
   );
 }

--- a/app/(erp)/(admin)/admin/attendance/_components/admin-attendance-today-view.tsx
+++ b/app/(erp)/(admin)/admin/attendance/_components/admin-attendance-today-view.tsx
@@ -1,252 +1,1095 @@
 "use client";
 
+import { SearchIcon, TriangleAlertIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Empty,
   EmptyDescription,
   EmptyHeader,
   EmptyTitle,
 } from "@/components/ui/empty";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { AdminAttendanceTodayResponse } from "@/lib/contracts/admin-attendance";
+import { cn } from "@/lib/utils";
 
 import {
   formatDateLabel,
+  formatMinutesLabel,
   formatTimeLabel,
-  getDisplaySummary,
-  getManualRequestActionLabel,
-  getManualRequestStatusLabel,
 } from "../_lib/formatting";
-import { groupAdminAttendanceTodayRows } from "../_lib/page-state";
+import type {
+  AdminAttendanceLedgerView,
+  AdminAttendanceTodayExceptionRow,
+} from "../_lib/today-exception-rows";
 import { AdminAttendanceSummaryCards } from "./admin-attendance-summary-cards";
 
 type AdminAttendanceTodayViewProps = {
+  exceptionRows: AdminAttendanceTodayExceptionRow[];
+  name?: string;
+  onNameChange?: (name: string) => void;
   response: AdminAttendanceTodayResponse;
 };
 
 type TodayItem = AdminAttendanceTodayResponse["items"][number];
 
-function isTodayQueueItem(item: TodayItem) {
-  return (
-    item.latestFailedAttempt !== null ||
-    item.manualRequest !== null ||
-    item.display.activeExceptions.length > 0 ||
-    item.display.flags.includes("late")
+type BadgeTone = "danger" | "info" | "neutral" | "success" | "warning";
+
+type ItemBadge = Readonly<{
+  label: string;
+  tone: BadgeTone;
+}>;
+
+const ledgerViewOptions: ReadonlyArray<{
+  label: string;
+  value: AdminAttendanceLedgerView;
+}> = [
+  { label: "기본", value: "default" },
+  { label: "근무상태별", value: "by-work-state" },
+  { label: "근태상태별", value: "by-attendance-status" },
+];
+
+function getLeaveCoverageLabel(item: TodayItem) {
+  switch (item.expectedWorkday.leaveCoverage?.leaveType) {
+    case "annual":
+      return "연차";
+    case "half_am":
+    case "half_pm":
+      return "반차";
+    case "hourly":
+      return "시간차";
+    default:
+      return null;
+  }
+}
+
+function getBadgeClassName(tone: BadgeTone) {
+  if (tone === "danger") {
+    return "bg-status-danger-soft text-status-danger";
+  }
+
+  if (tone === "warning") {
+    return "bg-status-warning-soft text-status-warning";
+  }
+
+  if (tone === "info") {
+    return "bg-status-info-soft text-status-info";
+  }
+
+  if (tone === "success") {
+    return "bg-status-success-soft text-status-success";
+  }
+
+  return "bg-muted text-secondary";
+}
+
+function getItemBadges(item: TodayItem) {
+  const badges: ItemBadge[] = [];
+  const leaveCoverageLabel = getLeaveCoverageLabel(item);
+
+  if (item.previousDayOpenRecord !== null) {
+    badges.push({
+      label: "전날 미퇴근",
+      tone: "danger",
+    });
+  }
+
+  if (item.latestFailedAttempt !== null) {
+    badges.push({
+      label: "시도 실패",
+      tone: "warning",
+    });
+  }
+
+  if (item.manualRequest !== null) {
+    badges.push({
+      label:
+        item.manualRequest.status === "pending"
+          ? "정정 요청 검토 중"
+          : item.manualRequest.status === "revision_requested"
+            ? "정정 요청 보완 필요"
+            : "정정 요청 반려",
+      tone: item.manualRequest.status === "pending" ? "info" : "warning",
+    });
+  }
+
+  if (item.display.activeExceptions.includes("leave_work_conflict")) {
+    badges.push({
+      label: "휴가 충돌",
+      tone: "info",
+    });
+  }
+
+  if (item.display.activeExceptions.includes("not_checked_in")) {
+    badges.push({
+      label: "출근 기록 없음",
+      tone: "danger",
+    });
+  }
+
+  if (item.display.activeExceptions.includes("absent")) {
+    badges.push({
+      label: "결근",
+      tone: "danger",
+    });
+  }
+
+  if (item.display.flags.includes("late")) {
+    badges.push({
+      label: "지각",
+      tone: "warning",
+    });
+  }
+
+  if (item.display.flags.includes("early_leave")) {
+    badges.push({
+      label: "조퇴",
+      tone: "warning",
+    });
+  }
+
+  if (leaveCoverageLabel !== null) {
+    badges.push({
+      label: leaveCoverageLabel,
+      tone: "info",
+    });
+  }
+
+  const seen = new Set<string>();
+
+  return badges.filter((badge) => {
+    if (seen.has(badge.label)) {
+      return false;
+    }
+
+    seen.add(badge.label);
+    return true;
+  });
+}
+
+function getCurrentStateLabel(item: TodayItem) {
+  if (item.previousDayOpenRecord !== null) {
+    return "전날 퇴근 기록이 아직 없어요";
+  }
+
+  if (item.latestFailedAttempt !== null) {
+    return "출결 시도가 실패했어요";
+  }
+
+  if (item.manualRequest !== null) {
+    if (item.manualRequest.status === "pending") {
+      return "정정 요청을 검토 중이에요";
+    }
+
+    if (item.manualRequest.status === "revision_requested") {
+      return "정정 요청 보완이 필요해요";
+    }
+
+    return "정정 요청이 반려됐어요";
+  }
+
+  if (item.display.activeExceptions.includes("leave_work_conflict")) {
+    return "휴가와 실제 근무 기록이 함께 있어요";
+  }
+
+  if (item.display.activeExceptions.includes("not_checked_in")) {
+    return "오늘 출근 기록이 없어요";
+  }
+
+  if (item.display.activeExceptions.includes("absent")) {
+    return "오늘 근무 기록이 비어 있어요";
+  }
+
+  if (
+    item.display.flags.includes("late") &&
+    item.display.flags.includes("early_leave")
+  ) {
+    return "지각과 조퇴가 함께 있어요";
+  }
+
+  if (item.display.flags.includes("late")) {
+    return "오늘 지각이 기록됐어요";
+  }
+
+  if (item.display.flags.includes("early_leave")) {
+    return "오늘 조퇴가 기록됐어요";
+  }
+
+  const leaveCoverageLabel = getLeaveCoverageLabel(item);
+
+  if (leaveCoverageLabel !== null) {
+    return `${leaveCoverageLabel}가 반영됐어요`;
+  }
+
+  if (item.display.phase === "working") {
+    return "지금 근무중이에요";
+  }
+
+  if (item.display.phase === "checked_out") {
+    return "오늘 근무를 마쳤어요";
+  }
+
+  return "아직 출근 전이에요";
+}
+
+function getContextLabel(item: TodayItem) {
+  if (item.previousDayOpenRecord !== null) {
+    return `대상일 ${formatDateLabel(item.previousDayOpenRecord.date)} · 전날 출근 ${formatTimeLabel(item.previousDayOpenRecord.clockInAt)} / 예상 퇴근 ${formatTimeLabel(item.previousDayOpenRecord.expectedClockOutAt)}`;
+  }
+
+  if (item.latestFailedAttempt !== null) {
+    return `마지막 시도 ${formatTimeLabel(item.latestFailedAttempt.attemptedAt)} · ${item.latestFailedAttempt.failureReason.replace(/[.。]\s*$/, "")}`;
+  }
+
+  if (item.manualRequest !== null) {
+    if (item.manualRequest.governingReviewComment !== null) {
+      return item.manualRequest.governingReviewComment;
+    }
+
+    return `대상일 ${formatDateLabel(item.manualRequest.date)} · ${formatTimeLabel(item.manualRequest.submittedAt)} 제출`;
+  }
+
+  if (item.display.activeExceptions.includes("leave_work_conflict")) {
+    return "휴가 일정과 실제 출결이 함께 보여요";
+  }
+
+  if (item.display.activeExceptions.includes("not_checked_in")) {
+    return `예상 출근 ${formatTimeLabel(item.expectedWorkday.adjustedClockInAt)} 이후에도 기록이 없어요`;
+  }
+
+  if (item.display.activeExceptions.includes("absent")) {
+    return "출근과 퇴근 기록 모두 다시 확인이 필요해요";
+  }
+
+  if (item.display.flags.includes("late")) {
+    return `출근 ${formatTimeLabel(item.todayRecord?.clockInAt ?? null)} · 퇴근 ${formatTimeLabel(item.todayRecord?.clockOutAt ?? null)}`;
+  }
+
+  if (item.display.flags.includes("early_leave")) {
+    return `출근 ${formatTimeLabel(item.todayRecord?.clockInAt ?? null)} · 퇴근 ${formatTimeLabel(item.todayRecord?.clockOutAt ?? null)}`;
+  }
+
+  const leaveCoverageLabel = getLeaveCoverageLabel(item);
+
+  if (leaveCoverageLabel !== null) {
+    return `${leaveCoverageLabel} 일정이 오늘 근무 시간에 반영돼 있어요`;
+  }
+
+  if (item.todayRecord !== null) {
+    return `출근 ${formatTimeLabel(item.todayRecord.clockInAt)} · 퇴근 ${formatTimeLabel(item.todayRecord.clockOutAt)}`;
+  }
+
+  return "오늘 장부를 확인해요";
+}
+
+function getNextCheckLabel(item: TodayItem) {
+  if (item.previousDayOpenRecord !== null) {
+    return "전날 퇴근 기록 확인";
+  }
+
+  if (item.latestFailedAttempt !== null) {
+    return "실패한 시도 확인";
+  }
+
+  if (item.manualRequest !== null) {
+    return "정정 요청 상태 확인";
+  }
+
+  if (item.display.activeExceptions.includes("leave_work_conflict")) {
+    return "휴가와 출결 비교";
+  }
+
+  if (item.display.activeExceptions.includes("not_checked_in")) {
+    return "출근 기록 확인";
+  }
+
+  if (item.display.activeExceptions.includes("absent")) {
+    return "출근과 퇴근 기록 재확인";
+  }
+
+  if (item.display.flags.includes("late")) {
+    return "지각 사유 확인";
+  }
+
+  if (item.display.flags.includes("early_leave")) {
+    return "조퇴 사유 확인";
+  }
+
+  return "오늘 장부 확인";
+}
+
+function getSearchableEmployeeValue(item: TodayItem) {
+  return `${item.employee.name} ${item.employee.department}`.toLocaleLowerCase(
+    "ko-KR",
   );
 }
 
-const groupMetadata = [
-  {
-    key: "failedAttempts",
-    title: "실패한 시도",
-    description: "비콘 또는 앱 확인이 실패한 시도예요.",
-  },
-  {
-    key: "manualRequests",
-    title: "정정 요청 상태",
-    description: "현재 근태를 설명하는 정정 요청 흐름이에요.",
-  },
-  {
-    key: "operationalRows",
-    title: "오늘 확인 필요",
-    description: "오늘 안에 사실 확인이 필요한 근태예요.",
-  },
-] as const;
+function getSearchableExceptionValue(row: AdminAttendanceTodayExceptionRow) {
+  return `${row.employeeName} ${row.department}`.toLocaleLowerCase("ko-KR");
+}
 
-function RowBadges({ item }: { item: TodayItem }) {
+function getWorkedMinutesBetween(startAt: string, endAt: string) {
+  const startedAt = new Date(startAt).getTime();
+  const finishedAt = new Date(endAt).getTime();
+
+  if (
+    Number.isNaN(startedAt) ||
+    Number.isNaN(finishedAt) ||
+    finishedAt < startedAt
+  ) {
+    return null;
+  }
+
+  return Math.floor((finishedAt - startedAt) / 60_000);
+}
+
+function getResolvedWorkMinutes(item: TodayItem, now: string) {
+  if (
+    item.todayRecord?.workMinutes !== null &&
+    item.todayRecord?.workMinutes !== undefined
+  ) {
+    return item.todayRecord.workMinutes;
+  }
+
+  if (
+    item.display.phase !== "working" ||
+    item.todayRecord?.clockInAt === null ||
+    item.todayRecord?.clockInAt === undefined
+  ) {
+    return null;
+  }
+
+  return getWorkedMinutesBetween(item.todayRecord.clockInAt, now);
+}
+
+function getTotalWorkTimeLabel(item: TodayItem, now: string) {
+  return formatMinutesLabel(getResolvedWorkMinutes(item, now));
+}
+
+function getLedgerRowToneClass(item: TodayItem) {
+  if (
+    item.previousDayOpenRecord !== null ||
+    item.display.activeExceptions.includes("not_checked_in") ||
+    item.display.activeExceptions.includes("absent")
+  ) {
+    return "bg-status-danger-soft/28 hover:bg-status-danger-soft/40";
+  }
+
+  if (
+    item.latestFailedAttempt !== null ||
+    item.display.flags.includes("late") ||
+    item.display.flags.includes("early_leave") ||
+    item.manualRequest !== null
+  ) {
+    return "bg-status-warning-soft/22 hover:bg-status-warning-soft/34";
+  }
+
+  if (item.display.activeExceptions.includes("leave_work_conflict")) {
+    return "bg-status-info-soft/38 hover:bg-status-info-soft/50";
+  }
+
+  return "";
+}
+
+function getExceptionRowToneClass(row: AdminAttendanceTodayExceptionRow) {
+  if (row.specialNote !== "-" || row.exceptionType.includes("결근")) {
+    return "bg-status-danger-soft/28 hover:bg-status-danger-soft/40";
+  }
+
+  if (
+    row.exceptionType.includes("실패") ||
+    row.exceptionType.includes("반려") ||
+    row.exceptionType.includes("검토")
+  ) {
+    return "bg-status-warning-soft/22 hover:bg-status-warning-soft/34";
+  }
+
+  if (row.exceptionType.includes("휴가")) {
+    return "bg-status-info-soft/38 hover:bg-status-info-soft/50";
+  }
+
+  return "";
+}
+
+function getWorkStateGroupKey(item: TodayItem) {
+  if (item.expectedWorkday.leaveCoverage !== null) {
+    return "on-leave";
+  }
+
+  if (item.display.phase === "working") {
+    return "working";
+  }
+
+  if (item.display.phase === "checked_out") {
+    return "checked-out";
+  }
+
+  return "before-check-in";
+}
+
+function getAttendanceStatusGroupKeys(item: TodayItem) {
+  const groups: Array<"early-leave" | "late" | "normal"> = [];
+
+  if (item.display.flags.includes("late")) {
+    groups.push("late");
+  }
+
+  if (item.display.flags.includes("early_leave")) {
+    groups.push("early-leave");
+  }
+
+  if (groups.length === 0) {
+    groups.push("normal");
+  }
+
+  return groups;
+}
+
+function StatusBadges({ item }: Readonly<{ item: TodayItem }>) {
+  const badges = getItemBadges(item);
+
+  if (badges.length === 0) {
+    return <span className="text-sm text-muted-foreground">-</span>;
+  }
+
   return (
-    <div className="flex flex-wrap gap-2">
-      {item.latestFailedAttempt !== null ? (
+    <div className="flex flex-wrap gap-1.5">
+      {badges.map((badge) => (
         <Badge
-          className="bg-status-warning-soft text-status-warning"
-          variant="ghost"
+          key={`${item.employee.id}-${badge.label}`}
+          className={getBadgeClassName(badge.tone)}
         >
-          시도 실패
+          {badge.label}
         </Badge>
-      ) : null}
-      {item.manualRequest !== null ? (
-        <Badge variant="default">정정 요청</Badge>
-      ) : null}
-      {item.display.activeExceptions.includes("not_checked_in") ? (
-        <Badge
-          className="bg-status-danger-soft text-status-danger"
-          variant="ghost"
-        >
-          출근 기록 없음
-        </Badge>
-      ) : null}
-      {item.display.flags.includes("late") ? (
-        <Badge
-          className="bg-status-warning-soft text-status-warning"
-          variant="ghost"
-        >
-          지각
-        </Badge>
-      ) : null}
-      {item.expectedWorkday.leaveCoverage !== null ? (
-        <Badge className="bg-status-info-soft text-status-info" variant="ghost">
-          휴가 반영
-        </Badge>
-      ) : null}
+      ))}
     </div>
   );
 }
 
-function TodayQueueRow({ item }: { item: TodayItem }) {
-  const expectedWindow =
-    item.expectedWorkday.adjustedClockInAt === null &&
-    item.expectedWorkday.adjustedClockOutAt === null
-      ? "휴가로 오늘 기본 근무 시간이 없어요."
-      : `${formatTimeLabel(item.expectedWorkday.adjustedClockInAt)} ~ ${formatTimeLabel(item.expectedWorkday.adjustedClockOutAt)}`;
+function SelectionSummaryPanel({ item }: Readonly<{ item: TodayItem | null }>) {
+  if (item === null) {
+    return null;
+  }
 
   return (
-    <li className="rounded-[14px] border border-border bg-surface-subtle/70">
-      <div className="flex flex-col gap-3 p-4">
-        <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
-          <div className="flex flex-col gap-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="font-medium text-foreground">
-                {item.employee.name}
-              </p>
-              <p className="text-sm text-muted-foreground">
-                {item.employee.department}
-              </p>
-            </div>
-            <p className="text-sm text-foreground">
-              {item.latestFailedAttempt !== null
-                ? "출결 시도가 확인되지 않았어요."
-                : item.manualRequest !== null
-                  ? getManualRequestStatusLabel(item.manualRequest)
-                  : getDisplaySummary(item.display)}
-            </p>
-          </div>
-          <RowBadges item={item} />
+    <Card className="border-primary/20 bg-primary/5 shadow-none">
+      <CardHeader className="gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <CardTitle>{item.employee.name}</CardTitle>
+          <Badge variant="outline">{item.employee.department}</Badge>
         </div>
+        <CardDescription>{getCurrentStateLabel(item)}</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-4 md:grid-cols-3">
+        <div className="flex flex-col gap-1.5">
+          <p className="text-xs font-medium text-muted-foreground">현재 상태</p>
+          <p className="text-sm leading-6 text-foreground">
+            {getCurrentStateLabel(item)}
+          </p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <p className="text-xs font-medium text-muted-foreground">사유</p>
+          <p className="text-sm leading-6 text-foreground">
+            {getContextLabel(item)}
+          </p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <p className="text-xs font-medium text-muted-foreground">
+            다음 확인 포인트
+          </p>
+          <p className="text-sm leading-6 text-foreground">
+            {getNextCheckLabel(item)}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
-        <dl className="grid gap-2 text-sm text-muted-foreground md:grid-cols-2 xl:grid-cols-4">
-          <div className="flex flex-col gap-1">
-            <dt>기준 시간</dt>
-            <dd className="text-foreground">{expectedWindow}</dd>
+function ExceptionTable({
+  hasAnyRows,
+  name,
+  onNameChange,
+  onSelectRow,
+  rows,
+  selectedRowId,
+}: Readonly<{
+  hasAnyRows: boolean;
+  name?: string;
+  onNameChange?: (name: string) => void;
+  onSelectRow: (row: AdminAttendanceTodayExceptionRow) => void;
+  rows: AdminAttendanceTodayExceptionRow[];
+  selectedRowId: string | null;
+}>) {
+  return (
+    <Card>
+      <CardHeader className="gap-4">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <TriangleAlertIcon
+                aria-hidden="true"
+                className="size-4 text-status-danger"
+              />
+              <CardTitle>누적 예외</CardTitle>
+              <Badge className="bg-status-danger-soft text-status-danger">
+                {rows.length}
+              </Badge>
+            </div>
+            <CardDescription>
+              직원 화면에서 아직 해소되지 않은 예외를 한 번에 모아봐요
+            </CardDescription>
           </div>
-          <div className="flex flex-col gap-1">
-            <dt>출근</dt>
-            <dd className="text-foreground">
-              {formatTimeLabel(item.todayRecord?.clockInAt ?? null)}
-            </dd>
-          </div>
-          <div className="flex flex-col gap-1">
-            <dt>퇴근</dt>
-            <dd className="text-foreground">
-              {formatTimeLabel(item.todayRecord?.clockOutAt ?? null)}
-            </dd>
-          </div>
-          <div className="flex flex-col gap-1">
-            <dt>다음 확인</dt>
-            <dd className="text-foreground">
-              {item.latestFailedAttempt !== null
-                ? "실패 사유 확인"
-                : item.manualRequest !== null
-                  ? "정정 요청 상태 확인"
-                  : "오늘 기록 확인"}
-            </dd>
-          </div>
-        </dl>
 
-        {item.latestFailedAttempt !== null ? (
-          <div className="rounded-[12px] bg-white px-3 py-2 text-sm text-muted-foreground">
-            <p className="font-medium text-foreground">
-              마지막 실패{" "}
-              {formatTimeLabel(item.latestFailedAttempt.attemptedAt)}
-            </p>
-            <p className="break-words">
-              {item.latestFailedAttempt.failureReason}
-            </p>
+          <div className="w-full max-w-[320px]">
+            <Label
+              className="mb-2 inline-flex text-sm font-medium text-foreground"
+              htmlFor="admin-attendance-name-search"
+            >
+              이름 검색
+            </Label>
+            <div className="relative">
+              <SearchIcon
+                aria-hidden="true"
+                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                autoComplete="off"
+                id="admin-attendance-name-search"
+                className="pl-9"
+                name="name"
+                placeholder="이름이나 부서로 찾아요…"
+                type="search"
+                value={name ?? ""}
+                onChange={(event) => onNameChange?.(event.target.value)}
+              />
+            </div>
           </div>
-        ) : null}
+        </div>
+      </CardHeader>
 
-        {item.manualRequest !== null ? (
-          <div className="rounded-[12px] bg-white px-3 py-2 text-sm text-muted-foreground">
-            <p className="font-medium text-foreground">
-              {getManualRequestActionLabel(item.manualRequest.action)} · 대상일{" "}
-              {formatDateLabel(item.manualRequest.date)}
-            </p>
-            <p>
-              제출 상태 {getManualRequestStatusLabel(item.manualRequest)} / 제출
-              시각 {formatTimeLabel(item.manualRequest.submittedAt)}
-            </p>
-            {item.manualRequest.governingReviewComment !== null ? (
-              <p className="break-words text-foreground">
-                {item.manualRequest.governingReviewComment}
-              </p>
-            ) : null}
+      <CardContent className="p-0">
+        {rows.length === 0 ? (
+          <Empty className="rounded-none border-0">
+            <EmptyHeader>
+              <EmptyTitle>
+                {hasAnyRows
+                  ? "검색 결과에 맞는 예외가 없어요"
+                  : "지금 누적 예외가 없어요"}
+              </EmptyTitle>
+              <EmptyDescription>
+                {hasAnyRows
+                  ? "검색어를 지우면 다른 누적 예외를 바로 확인할 수 있어요"
+                  : "새로운 예외가 생기면 이 표에서 먼저 보여줘요"}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>직원</TableHead>
+                  <TableHead>부서</TableHead>
+                  <TableHead>예외 유형</TableHead>
+                  <TableHead>특이사항</TableHead>
+                  <TableHead>기준일</TableHead>
+                  <TableHead>상세</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => {
+                  const isSelected = row.id === selectedRowId;
+
+                  return (
+                    <TableRow
+                      key={row.id}
+                      aria-selected={isSelected}
+                      className={cn(
+                        "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-inset",
+                        getExceptionRowToneClass(row),
+                        isSelected &&
+                          "bg-primary/8 hover:bg-primary/10 data-[state=selected]:bg-primary/8",
+                      )}
+                      data-state={isSelected ? "selected" : undefined}
+                      tabIndex={0}
+                      onClick={() => onSelectRow(row)}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") {
+                          return;
+                        }
+
+                        event.preventDefault();
+                        onSelectRow(row);
+                      }}
+                    >
+                      <TableCell className="font-medium text-foreground">
+                        {row.employeeName}
+                      </TableCell>
+                      <TableCell>{row.department}</TableCell>
+                      <TableCell>{row.exceptionType}</TableCell>
+                      <TableCell>{row.specialNote}</TableCell>
+                      <TableCell className="whitespace-nowrap text-foreground tabular-nums">
+                        {formatDateLabel(row.referenceDate)}
+                      </TableCell>
+                      <TableCell className="min-w-[280px] text-secondary">
+                        {row.detail}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
           </div>
-        ) : null}
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function LedgerTable({
+  items,
+  now,
+  onSelectEmployee,
+  selectedEmployeeId,
+}: Readonly<{
+  items: TodayItem[];
+  now: string;
+  onSelectEmployee: (employeeId: string) => void;
+  selectedEmployeeId: string | null;
+}>) {
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>직원</TableHead>
+            <TableHead>부서</TableHead>
+            <TableHead>현재 상태</TableHead>
+            <TableHead>출근</TableHead>
+            <TableHead>퇴근</TableHead>
+            <TableHead>총 근무시간</TableHead>
+            <TableHead>다음 확인</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((item) => {
+            const isSelected = item.employee.id === selectedEmployeeId;
+
+            return (
+              <TableRow
+                key={item.employee.id}
+                aria-selected={isSelected}
+                className={cn(
+                  "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-inset",
+                  getLedgerRowToneClass(item),
+                  isSelected &&
+                    "bg-primary/8 hover:bg-primary/10 data-[state=selected]:bg-primary/8",
+                )}
+                data-state={isSelected ? "selected" : undefined}
+                tabIndex={0}
+                onClick={() => onSelectEmployee(item.employee.id)}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter" && event.key !== " ") {
+                    return;
+                  }
+
+                  event.preventDefault();
+                  onSelectEmployee(item.employee.id);
+                }}
+              >
+                <TableCell className="whitespace-normal">
+                  <div className="flex flex-col gap-1">
+                    <span className="font-medium text-foreground">
+                      {item.employee.name}
+                    </span>
+                    <span className="text-xs leading-5 text-secondary">
+                      {getContextLabel(item)}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell>{item.employee.department}</TableCell>
+                <TableCell className="whitespace-normal">
+                  <div className="flex flex-col gap-2">
+                    <p className="font-medium text-foreground">
+                      {getCurrentStateLabel(item)}
+                    </p>
+                    <StatusBadges item={item} />
+                  </div>
+                </TableCell>
+                <TableCell className="whitespace-nowrap text-foreground tabular-nums">
+                  {formatTimeLabel(item.todayRecord?.clockInAt ?? null)}
+                </TableCell>
+                <TableCell className="whitespace-nowrap text-foreground tabular-nums">
+                  {formatTimeLabel(item.todayRecord?.clockOutAt ?? null)}
+                </TableCell>
+                <TableCell className="whitespace-nowrap text-foreground tabular-nums">
+                  {getTotalWorkTimeLabel(item, now)}
+                </TableCell>
+                <TableCell className="whitespace-normal text-secondary">
+                  {getNextCheckLabel(item)}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function LedgerSection({
+  description,
+  items,
+  now,
+  onSelectEmployee,
+  selectedEmployeeId,
+  title,
+}: Readonly<{
+  description: string;
+  items: TodayItem[];
+  now: string;
+  onSelectEmployee: (employeeId: string) => void;
+  selectedEmployeeId: string | null;
+  title: string;
+}>) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-sm font-medium text-foreground">{title}</h3>
+          <p className="text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+        </div>
+        <Badge variant="outline">{items.length}명</Badge>
       </div>
-    </li>
+
+      {items.length === 0 ? (
+        <Empty className="border border-border bg-card">
+          <EmptyHeader>
+            <EmptyTitle>{title} 항목이 없어요</EmptyTitle>
+            <EmptyDescription>
+              다른 view에서 전체 장부를 계속 볼 수 있어요
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <LedgerTable
+          items={items}
+          now={now}
+          onSelectEmployee={onSelectEmployee}
+          selectedEmployeeId={selectedEmployeeId}
+        />
+      )}
+    </div>
+  );
+}
+
+function LedgerContent({
+  items,
+  now,
+  onSelectEmployee,
+  selectedEmployeeId,
+  view,
+}: Readonly<{
+  items: TodayItem[];
+  now: string;
+  onSelectEmployee: (employeeId: string) => void;
+  selectedEmployeeId: string | null;
+  view: AdminAttendanceLedgerView;
+}>) {
+  if (items.length === 0) {
+    return (
+      <Empty className="border border-border bg-card">
+        <EmptyHeader>
+          <EmptyTitle>검색 결과가 없어요</EmptyTitle>
+          <EmptyDescription>
+            다른 이름으로 찾아보거나 검색어를 지우면 전체 장부를 다시 볼 수
+            있어요
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  if (view === "default") {
+    return (
+      <LedgerTable
+        items={items}
+        now={now}
+        onSelectEmployee={onSelectEmployee}
+        selectedEmployeeId={selectedEmployeeId}
+      />
+    );
+  }
+
+  if (view === "by-work-state") {
+    const leaveItems = items.filter(
+      (item) => getWorkStateGroupKey(item) === "on-leave",
+    );
+    const workingItems = items.filter(
+      (item) => getWorkStateGroupKey(item) === "working",
+    );
+    const beforeCheckInItems = items.filter(
+      (item) => getWorkStateGroupKey(item) === "before-check-in",
+    );
+    const checkedOutItems = items.filter(
+      (item) => getWorkStateGroupKey(item) === "checked-out",
+    );
+
+    return (
+      <div className="flex flex-col gap-8">
+        <LedgerSection
+          description="휴가가 반영된 인원만 모아봐요"
+          items={leaveItems}
+          now={now}
+          title="휴가중"
+          onSelectEmployee={onSelectEmployee}
+          selectedEmployeeId={selectedEmployeeId}
+        />
+        <LedgerSection
+          description="현재 근무중인 인원이에요"
+          items={workingItems}
+          now={now}
+          title="근무중"
+          onSelectEmployee={onSelectEmployee}
+          selectedEmployeeId={selectedEmployeeId}
+        />
+        <LedgerSection
+          description="아직 출근 전으로 보이는 인원이에요"
+          items={beforeCheckInItems}
+          now={now}
+          title="출근 전"
+          onSelectEmployee={onSelectEmployee}
+          selectedEmployeeId={selectedEmployeeId}
+        />
+        <LedgerSection
+          description="오늘 근무를 마친 인원이에요"
+          items={checkedOutItems}
+          now={now}
+          title="퇴근"
+          onSelectEmployee={onSelectEmployee}
+          selectedEmployeeId={selectedEmployeeId}
+        />
+      </div>
+    );
+  }
+
+  const normalItems = items.filter((item) =>
+    getAttendanceStatusGroupKeys(item).includes("normal"),
+  );
+  const lateItems = items.filter((item) =>
+    getAttendanceStatusGroupKeys(item).includes("late"),
+  );
+  const earlyLeaveItems = items.filter((item) =>
+    getAttendanceStatusGroupKeys(item).includes("early-leave"),
+  );
+
+  return (
+    <div className="flex flex-col gap-8">
+      <LedgerSection
+        description="지각이나 조퇴 플래그가 없는 인원이에요"
+        items={normalItems}
+        now={now}
+        title="정상"
+        onSelectEmployee={onSelectEmployee}
+        selectedEmployeeId={selectedEmployeeId}
+      />
+      <LedgerSection
+        description="지각 플래그가 있는 인원이에요"
+        items={lateItems}
+        now={now}
+        title="지각"
+        onSelectEmployee={onSelectEmployee}
+        selectedEmployeeId={selectedEmployeeId}
+      />
+      <LedgerSection
+        description="조퇴 플래그가 있는 인원이에요"
+        items={earlyLeaveItems}
+        now={now}
+        title="조퇴"
+        onSelectEmployee={onSelectEmployee}
+        selectedEmployeeId={selectedEmployeeId}
+      />
+    </div>
+  );
+}
+
+function LedgerPanel({
+  items,
+  name,
+  onSelectEmployee,
+  selectedEmployeeId,
+  setLedgerView,
+  view,
+}: Readonly<{
+  items: TodayItem[];
+  name?: string;
+  onSelectEmployee: (employeeId: string) => void;
+  selectedEmployeeId: string | null;
+  setLedgerView: (view: AdminAttendanceLedgerView) => void;
+  view: AdminAttendanceLedgerView;
+}>) {
+  const [now, setNow] = useState(() => new Date().toISOString());
+  const selectedItem =
+    selectedEmployeeId === null
+      ? null
+      : (items.find((item) => item.employee.id === selectedEmployeeId) ?? null);
+
+  useEffect(() => {
+    const syncNow = () => {
+      setNow(new Date().toISOString());
+    };
+
+    syncNow();
+
+    const timerId = window.setInterval(syncNow, 60_000);
+
+    return () => {
+      window.clearInterval(timerId);
+    };
+  }, []);
+
+  return (
+    <Card className="scroll-mt-20" id="today-ledger">
+      <CardHeader className="gap-4">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+          <div className="flex flex-col gap-1">
+            <CardTitle>전체 팀 장부</CardTitle>
+            <CardDescription>
+              오늘 장부를 기본 view 또는 상태별 view로 나눠서 봐요
+            </CardDescription>
+          </div>
+          <ToggleGroup
+            className="rounded-[8px] border border-border/80 bg-muted/75 p-1"
+            spacing={1}
+            type="single"
+            value={view}
+            onValueChange={(value) => {
+              if (value === "" || value === view) {
+                return;
+              }
+
+              setLedgerView(value as AdminAttendanceLedgerView);
+            }}
+          >
+            {ledgerViewOptions.map((option) => (
+              <ToggleGroupItem
+                key={option.value}
+                className="rounded-[8px]"
+                value={option.value}
+              >
+                {option.label}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-5">
+        <SelectionSummaryPanel item={selectedItem} />
+
+        {selectedItem === null ? null : <Separator />}
+
+        <LedgerContent
+          items={items}
+          now={now}
+          onSelectEmployee={onSelectEmployee}
+          selectedEmployeeId={selectedEmployeeId}
+          view={view}
+        />
+      </CardContent>
+
+      <CardFooter className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+        <span>{items.length}명을 표시하고 있어요</span>
+        <span>
+          {name === undefined || name.trim().length === 0
+            ? "검색어 없음"
+            : `검색어 ${name}`}
+        </span>
+      </CardFooter>
+    </Card>
   );
 }
 
 export function AdminAttendanceTodayView({
+  exceptionRows,
+  name,
+  onNameChange,
   response,
 }: AdminAttendanceTodayViewProps) {
-  const groupedItems = groupAdminAttendanceTodayRows(
-    response.items.filter(isTodayQueueItem),
+  const [selectedEmployeeId, setSelectedEmployeeId] = useState<string | null>(
+    null,
   );
-  const hasQueueRows = Object.values(groupedItems).some(
-    (items) => items.length > 0,
-  );
+  const [selectedExceptionRowId, setSelectedExceptionRowId] = useState<
+    string | null
+  >(null);
+  const [ledgerView, setLedgerView] =
+    useState<AdminAttendanceLedgerView>("default");
+
+  const trimmedName = name?.trim() ?? "";
+  const normalizedName = trimmedName.toLocaleLowerCase("ko-KR");
+  const visibleItems =
+    normalizedName.length === 0
+      ? response.items
+      : response.items.filter((item) =>
+          getSearchableEmployeeValue(item).includes(normalizedName),
+        );
+  const visibleExceptionRows =
+    normalizedName.length === 0
+      ? exceptionRows
+      : exceptionRows.filter((row) =>
+          getSearchableExceptionValue(row).includes(normalizedName),
+        );
 
   return (
     <div className="flex flex-col gap-6">
-      <AdminAttendanceSummaryCards summary={response.summary} />
+      <ExceptionTable
+        hasAnyRows={exceptionRows.length > 0}
+        name={name}
+        onNameChange={onNameChange}
+        rows={visibleExceptionRows}
+        selectedRowId={selectedExceptionRowId}
+        onSelectRow={(row) => {
+          setSelectedExceptionRowId(row.id);
+          setSelectedEmployeeId(row.employeeId);
+        }}
+      />
 
-      <section className="flex flex-col gap-4" aria-label="오늘 운영 큐">
-        {!hasQueueRows ? (
-          <Empty className="border border-border bg-card">
-            <EmptyHeader>
-              <EmptyTitle>오늘 바로 확인할 근태가 없어요.</EmptyTitle>
-              <EmptyDescription>
-                지금은 예외 없이 운영 중이에요. 요약 카드에서 전체 상태를 확인할
-                수 있어요.
-              </EmptyDescription>
-            </EmptyHeader>
-          </Empty>
-        ) : null}
+      <AdminAttendanceSummaryCards items={visibleItems} />
 
-        {groupMetadata.map((group) => {
-          const items = groupedItems[group.key];
-
-          if (items.length === 0) {
-            return null;
-          }
-
-          return (
-            <Card key={group.key}>
-              <CardHeader className="gap-2">
-                <div className="flex items-center gap-2">
-                  <CardTitle>{group.title}</CardTitle>
-                  <span className="inline-flex size-5 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-secondary">
-                    {items.length}
-                  </span>
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  {group.description}
-                </p>
-              </CardHeader>
-              <CardContent>
-                <ul className="flex flex-col gap-3">
-                  {items.map((item) => (
-                    <TodayQueueRow
-                      key={`${group.key}-${item.employee.id}`}
-                      item={item}
-                    />
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          );
-        })}
-      </section>
+      <LedgerPanel
+        items={visibleItems}
+        name={name}
+        onSelectEmployee={(employeeId) => {
+          setSelectedEmployeeId(employeeId);
+          setSelectedExceptionRowId(null);
+        }}
+        selectedEmployeeId={selectedEmployeeId}
+        setLedgerView={setLedgerView}
+        view={ledgerView}
+      />
     </div>
   );
 }

--- a/app/(erp)/(admin)/admin/attendance/_components/admin-attendance-workspace.tsx
+++ b/app/(erp)/(admin)/admin/attendance/_components/admin-attendance-workspace.tsx
@@ -14,12 +14,14 @@ import {
   type AdminAttendanceUrlState,
   normalizeAdminAttendanceUrlState,
 } from "../_lib/page-state";
+import type { AdminAttendanceTodayExceptionRow } from "../_lib/today-exception-rows";
 import { AdminAttendanceHistoryView } from "./admin-attendance-history-view";
 import { AdminAttendanceTodayView } from "./admin-attendance-today-view";
 
 type AdminAttendanceWorkspaceProps = {
   historyResponse?: AdminAttendanceListResponse;
   state: AdminAttendanceUrlState;
+  todayExceptionRows?: AdminAttendanceTodayExceptionRow[];
   todayResponse?: AdminAttendanceTodayResponse;
 };
 
@@ -67,6 +69,7 @@ function getNextModeFromKey(
 export function AdminAttendanceWorkspace({
   historyResponse,
   state,
+  todayExceptionRows,
   todayResponse,
 }: AdminAttendanceWorkspaceProps) {
   const router = useRouter();
@@ -130,8 +133,21 @@ export function AdminAttendanceWorkspace({
       </TabsList>
 
       <TabsContent className="mt-0" value="today">
-        {todayResponse === undefined ? null : (
-          <AdminAttendanceTodayView response={todayResponse} />
+        {todayResponse === undefined ||
+        todayExceptionRows === undefined ? null : (
+          <AdminAttendanceTodayView
+            exceptionRows={todayExceptionRows}
+            name={state.name}
+            onNameChange={(name) =>
+              replaceState({
+                mode: "today",
+                ...(withOptionalName(name) === undefined
+                  ? { name: undefined }
+                  : { name: withOptionalName(name) }),
+              })
+            }
+            response={todayResponse}
+          />
         )}
       </TabsContent>
 

--- a/app/(erp)/(admin)/admin/attendance/_lib/formatting.ts
+++ b/app/(erp)/(admin)/admin/attendance/_lib/formatting.ts
@@ -84,6 +84,10 @@ export function getDisplaySummary(display: AttendanceDisplay) {
 }
 
 export function getHistoryDisplayStatusLabel(display: AttendanceDisplay) {
+  if (display.activeExceptions.includes("previous_day_checkout_missing")) {
+    return "전날 미퇴근";
+  }
+
   if (display.activeExceptions.includes("attempt_failed")) {
     return "시도 실패";
   }

--- a/app/(erp)/(admin)/admin/attendance/_lib/load-admin-attendance-screen-data.ts
+++ b/app/(erp)/(admin)/admin/attendance/_lib/load-admin-attendance-screen-data.ts
@@ -4,6 +4,7 @@ import {
 } from "@/lib/api/admin-attendance";
 
 import type { AdminAttendanceUrlState } from "./page-state";
+import { buildAdminAttendanceTodayExceptionRows } from "./today-exception-rows";
 
 type LoadAdminAttendanceScreenDataInput = {
   baseUrl: string;
@@ -24,12 +25,16 @@ export async function loadAdminAttendanceScreenData({
         },
         { baseUrl },
       ),
+      todayExceptionRows: undefined,
       todayResponse: undefined,
     };
   }
 
+  const todayResponse = await fetchAdminAttendanceToday({ baseUrl });
+
   return {
     historyResponse: undefined,
-    todayResponse: await fetchAdminAttendanceToday({ baseUrl }),
+    todayExceptionRows: buildAdminAttendanceTodayExceptionRows(todayResponse),
+    todayResponse,
   };
 }

--- a/app/(erp)/(admin)/admin/attendance/_lib/page-state.ts
+++ b/app/(erp)/(admin)/admin/attendance/_lib/page-state.ts
@@ -23,6 +23,7 @@ export type AdminAttendanceTodayItem =
   import("@/lib/contracts/admin-attendance").AdminAttendanceTodayResponse["items"][number];
 
 export type AdminAttendanceTodayRowGroups = {
+  previousDayOpen: AdminAttendanceTodayItem[];
   failedAttempts: AdminAttendanceTodayItem[];
   manualRequests: AdminAttendanceTodayItem[];
   operationalRows: AdminAttendanceTodayItem[];
@@ -99,12 +100,18 @@ export function groupAdminAttendanceTodayRows(
   items: AdminAttendanceTodayItem[],
 ): AdminAttendanceTodayRowGroups {
   const grouped: AdminAttendanceTodayRowGroups = {
+    previousDayOpen: [],
     failedAttempts: [],
     manualRequests: [],
     operationalRows: [],
   };
 
   for (const item of items) {
+    if (item.previousDayOpenRecord !== null) {
+      grouped.previousDayOpen.push(item);
+      continue;
+    }
+
     if (item.latestFailedAttempt !== null) {
       grouped.failedAttempts.push(item);
       continue;

--- a/app/(erp)/(admin)/admin/attendance/_lib/today-exception-rows.ts
+++ b/app/(erp)/(admin)/admin/attendance/_lib/today-exception-rows.ts
@@ -1,0 +1,407 @@
+import {
+  buildExceptionSurfaceModels,
+  buildHistoryAction,
+} from "@/app/(erp)/(employee)/attendance/_lib/view-model";
+import type { AdminAttendanceTodayResponse } from "@/lib/contracts/admin-attendance";
+import {
+  createMockSeedRepository,
+  getMockSeedWorld,
+} from "@/lib/server/mock-state";
+
+export type AdminAttendanceTodayExceptionRow = Readonly<{
+  department: string;
+  detail: string;
+  employeeId: string;
+  employeeName: string;
+  exceptionType: string;
+  id: string;
+  referenceDate: string;
+  specialNote: string;
+}>;
+
+export type AdminAttendanceLedgerView =
+  | "default"
+  | "by-attendance-status"
+  | "by-work-state";
+
+type EmployeeHistoryRecord = ReturnType<
+  ReturnType<typeof createMockSeedRepository>["getEmployeeAttendanceHistory"]
+>["records"][number];
+
+type SortableExceptionRow = AdminAttendanceTodayExceptionRow &
+  Readonly<{
+    priority: number;
+  }>;
+
+function getCurrentSurfacePriority(surfaceId: string) {
+  if (surfaceId === "previous-day-checkout-missing") {
+    return 0;
+  }
+
+  if (surfaceId.startsWith("attempt-failed")) {
+    return 1;
+  }
+
+  if (surfaceId === "manual-request-summary") {
+    return 2;
+  }
+
+  if (surfaceId === "leave-work-conflict") {
+    return 3;
+  }
+
+  return 4;
+}
+
+function getCurrentSurfaceExceptionType(
+  surface: ReturnType<typeof buildExceptionSurfaceModels>[number],
+) {
+  if (surface.id === "previous-day-checkout-missing") {
+    return "전날 미퇴근";
+  }
+
+  if (surface.id.startsWith("attempt-failed")) {
+    return "시도 실패";
+  }
+
+  if (surface.id === "manual-request-summary") {
+    if (surface.title.includes("보완")) {
+      return "정정 요청 보완 필요";
+    }
+
+    if (surface.title.includes("조정")) {
+      return "정정 요청 반려";
+    }
+
+    return "정정 요청 검토 중";
+  }
+
+  if (surface.id === "leave-work-conflict") {
+    return "휴가 충돌";
+  }
+
+  if (surface.id === "not-checked-in") {
+    return "출근 기록 없음";
+  }
+
+  return "근무 기록 비어 있음";
+}
+
+function getCurrentSurfaceSpecialNote(
+  surface: ReturnType<typeof buildExceptionSurfaceModels>[number],
+) {
+  if (surface.id === "previous-day-checkout-missing") {
+    return "퇴근 누락";
+  }
+
+  if (surface.id === "not-checked-in") {
+    return "출근 누락";
+  }
+
+  if (surface.id === "absent") {
+    return "출근/퇴근 누락";
+  }
+
+  return "-";
+}
+
+function getCurrentSurfaceReferenceDate(
+  item: AdminAttendanceTodayResponse["items"][number],
+  surface: ReturnType<typeof buildExceptionSurfaceModels>[number],
+  todayDate: string,
+) {
+  if (surface.id === "previous-day-checkout-missing") {
+    return item.previousDayOpenRecord?.date ?? todayDate;
+  }
+
+  if (surface.id.startsWith("attempt-failed")) {
+    return item.latestFailedAttempt?.date ?? todayDate;
+  }
+
+  if (surface.id === "manual-request-summary") {
+    return item.manualRequest?.date ?? todayDate;
+  }
+
+  return todayDate;
+}
+
+function getHistorySpecialNoteLabel(
+  record: EmployeeHistoryRecord,
+  todayDate: string,
+) {
+  if (!record.expectedWorkday.isWorkday) {
+    return "휴일";
+  }
+
+  if (
+    record.date < todayDate &&
+    record.record?.clockInAt !== null &&
+    record.record?.clockInAt !== undefined &&
+    record.record.clockOutAt === null
+  ) {
+    return "퇴근 누락";
+  }
+
+  if (record.display.activeExceptions.includes("not_checked_in")) {
+    return "출근 누락";
+  }
+
+  if (record.display.activeExceptions.includes("absent")) {
+    return "출근/퇴근 누락";
+  }
+
+  return "-";
+}
+
+function getHistoryExceptionTypeLabels(
+  record: EmployeeHistoryRecord,
+  todayDate: string,
+) {
+  const statuses: string[] = [];
+
+  if (
+    record.date < todayDate &&
+    record.record?.clockInAt !== null &&
+    record.record?.clockInAt !== undefined &&
+    record.record.clockOutAt === null
+  ) {
+    statuses.push("전날 미퇴근");
+  }
+
+  if (record.display.activeExceptions.includes("attempt_failed")) {
+    statuses.push("시도 실패");
+  }
+
+  if (record.display.activeExceptions.includes("manual_request_pending")) {
+    statuses.push("정정 요청 검토 중");
+  }
+
+  if (record.display.activeExceptions.includes("manual_request_rejected")) {
+    statuses.push("정정 요청 보완 필요");
+  }
+
+  if (record.display.activeExceptions.includes("not_checked_in")) {
+    statuses.push("출근 기록 없음");
+  }
+
+  if (record.display.activeExceptions.includes("absent")) {
+    statuses.push("결근");
+  }
+
+  return [...new Set(statuses)];
+}
+
+function hasHistoricalIssue(record: EmployeeHistoryRecord, todayDate: string) {
+  return getHistoryExceptionTypeLabels(record, todayDate).length > 0;
+}
+
+function getHistoricalPriority(
+  record: EmployeeHistoryRecord,
+  todayDate: string,
+) {
+  if (
+    record.date < todayDate &&
+    record.record?.clockInAt !== null &&
+    record.record?.clockInAt !== undefined &&
+    record.record.clockOutAt === null
+  ) {
+    return 0;
+  }
+
+  if (record.display.activeExceptions.includes("attempt_failed")) {
+    return 1;
+  }
+
+  if (
+    record.display.activeExceptions.includes("manual_request_pending") ||
+    record.display.activeExceptions.includes("manual_request_rejected")
+  ) {
+    return 2;
+  }
+
+  if (
+    record.display.activeExceptions.includes("not_checked_in") ||
+    record.display.activeExceptions.includes("absent")
+  ) {
+    return 4;
+  }
+
+  return 5;
+}
+
+function getHistoricalIssueDetails(
+  record: EmployeeHistoryRecord,
+  todayDate: string,
+) {
+  const specialNote = getHistorySpecialNoteLabel(record, todayDate);
+  const labels = [
+    ...getHistoryExceptionTypeLabels(record, todayDate),
+    specialNote === "-" || specialNote === "휴일" ? null : specialNote,
+  ].filter((label): label is string => label !== null);
+
+  return [...new Set(labels)];
+}
+
+function getHistoricalIssueDescription(issueLabels: string[]) {
+  if (issueLabels.length === 1) {
+    return `${issueLabels[0]} 상태가 남아 있어요`;
+  }
+
+  return `${issueLabels.join(", ")} 상태가 함께 남아 있어요`;
+}
+
+function getHistoricalExceptionType(issueLabels: string[]) {
+  if (issueLabels.length === 0) {
+    return "정정 필요";
+  }
+
+  return issueLabels.join(" · ");
+}
+
+function buildCurrentRows(input: {
+  item: AdminAttendanceTodayResponse["items"][number];
+  repository: ReturnType<typeof createMockSeedRepository>;
+  todayDate: string;
+}) {
+  const employeeToday = input.repository.getEmployeeAttendanceToday({
+    employeeId: input.item.employee.id,
+    date: input.todayDate,
+  });
+
+  const rows = buildExceptionSurfaceModels(
+    employeeToday,
+  ).map<SortableExceptionRow>((surface) => ({
+    department: input.item.employee.department,
+    detail: surface.description,
+    employeeId: input.item.employee.id,
+    employeeName: input.item.employee.name,
+    exceptionType: getCurrentSurfaceExceptionType(surface),
+    id: `current-${input.item.employee.id}-${surface.id}`,
+    priority: getCurrentSurfacePriority(surface.id),
+    referenceDate: getCurrentSurfaceReferenceDate(
+      input.item,
+      surface,
+      input.todayDate,
+    ),
+    specialNote: getCurrentSurfaceSpecialNote(surface),
+  }));
+
+  const hasFailedAttemptRow = rows.some((row) =>
+    row.id.includes("attempt-failed"),
+  );
+
+  if (!hasFailedAttemptRow && input.item.latestFailedAttempt !== null) {
+    rows.push({
+      department: input.item.employee.department,
+      detail: input.item.latestFailedAttempt.failureReason.replace(
+        /[.。]\s*$/,
+        "",
+      ),
+      employeeId: input.item.employee.id,
+      employeeName: input.item.employee.name,
+      exceptionType: "시도 실패",
+      id: `current-${input.item.employee.id}-attempt-failed-admin`,
+      priority: 1,
+      referenceDate: input.item.latestFailedAttempt.date,
+      specialNote: "-",
+    });
+  }
+
+  return rows;
+}
+
+function buildHistoricalRows(input: {
+  employeeId: string;
+  employeeName: string;
+  department: string;
+  repository: ReturnType<typeof createMockSeedRepository>;
+  todayDate: string;
+}) {
+  const history = input.repository.getEmployeeAttendanceHistory({
+    employeeId: input.employeeId,
+    from: getMockSeedWorld().calendarWindow.start,
+    to: input.todayDate,
+  });
+
+  return [...history.records]
+    .sort((left, right) => right.date.localeCompare(left.date))
+    .filter(
+      (record) =>
+        record.date < input.todayDate &&
+        hasHistoricalIssue(record, input.todayDate),
+    )
+    .flatMap((record) => {
+      const historyAction = buildHistoryAction(record);
+
+      if (historyAction === null) {
+        return [];
+      }
+
+      const issueLabels = getHistoricalIssueDetails(record, input.todayDate);
+      const exceptionTypeLabels = getHistoryExceptionTypeLabels(
+        record,
+        input.todayDate,
+      );
+
+      return [
+        {
+          department: input.department,
+          detail: getHistoricalIssueDescription(issueLabels),
+          employeeId: input.employeeId,
+          employeeName: input.employeeName,
+          exceptionType: getHistoricalExceptionType(exceptionTypeLabels),
+          id: `history-${input.employeeId}-${record.date}`,
+          priority: getHistoricalPriority(record, input.todayDate),
+          referenceDate: record.date,
+          specialNote: getHistorySpecialNoteLabel(record, input.todayDate),
+        } satisfies SortableExceptionRow,
+      ];
+    });
+}
+
+export function buildAdminAttendanceTodayExceptionRows(
+  today: AdminAttendanceTodayResponse,
+) {
+  const repository = createMockSeedRepository();
+
+  return today.items
+    .flatMap((item) => [
+      ...buildCurrentRows({
+        item,
+        repository,
+        todayDate: today.date,
+      }),
+      ...buildHistoricalRows({
+        department: item.employee.department,
+        employeeId: item.employee.id,
+        employeeName: item.employee.name,
+        repository,
+        todayDate: today.date,
+      }),
+    ])
+    .sort((left, right) => {
+      if (left.priority !== right.priority) {
+        return left.priority - right.priority;
+      }
+
+      if (left.priority === 5 && left.referenceDate !== right.referenceDate) {
+        return right.referenceDate.localeCompare(left.referenceDate);
+      }
+
+      if (left.referenceDate !== right.referenceDate) {
+        return left.referenceDate.localeCompare(right.referenceDate);
+      }
+
+      return left.employeeName.localeCompare(right.employeeName, "ko-KR");
+    })
+    .map<AdminAttendanceTodayExceptionRow>((row) => ({
+      department: row.department,
+      detail: row.detail,
+      employeeId: row.employeeId,
+      employeeName: row.employeeName,
+      exceptionType: row.exceptionType,
+      id: row.id,
+      referenceDate: row.referenceDate,
+      specialNote: row.specialNote,
+    }));
+}

--- a/app/(erp)/(admin)/admin/attendance/page.tsx
+++ b/app/(erp)/(admin)/admin/attendance/page.tsx
@@ -32,7 +32,7 @@ export default async function AdminAttendancePage(
     toUrlSearchParams(rawSearchParams),
   );
   const baseUrl = await getRequestOrigin();
-  const { historyResponse, todayResponse } =
+  const { historyResponse, todayExceptionRows, todayResponse } =
     await loadAdminAttendanceScreenData({
       baseUrl,
       state,
@@ -53,6 +53,7 @@ export default async function AdminAttendancePage(
       <AdminAttendanceWorkspace
         historyResponse={historyResponse}
         state={state}
+        todayExceptionRows={todayExceptionRows}
         todayResponse={todayResponse}
       />
     </div>

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -55,6 +55,7 @@ Attendance lifecycle semantics for `expectedWorkday`, `attendanceAttempt`, `atte
 - `attempt_failed`
 - `not_checked_in`
 - `absent`
+- `previous_day_checkout_missing`
 - `leave_work_conflict`
 - `manual_request_pending`
 - `manual_request_rejected`
@@ -64,6 +65,7 @@ Attendance lifecycle semantics for `expectedWorkday`, `attendanceAttempt`, `atte
 - `clock_in`
 - `clock_out`
 - `submit_manual_request`
+- `resolve_previous_day_checkout`
 - `review_request_status`
 - `review_leave_conflict`
 - `wait`
@@ -260,6 +262,19 @@ Fields:
 - `relatedRequestId`
 
 `phase` is derived in precedence order: `checked_out` when the requested date already has a same-day checkout fact, `working` when the requested date has a same-day check-in fact without checkout, `non_workday` when no same-day attendance fact exists and `expectedWorkday.isWorkday` is `false`, and `before_check_in` otherwise.
+
+`previous_day_checkout_missing` is evaluated against the `09:00` carry-over cutoff in the workday timezone carried by the attendance facts, not the transport timezone of the request itself.
+
+### `Previous Day Open Record`
+
+Represents the still-open prior workday when checkout is missing.
+
+Fields:
+
+- `date`
+- `clockInAt`
+- `clockOutAt`
+- `expectedClockOutAt`
 
 ## Employee Endpoints
 
@@ -860,7 +875,8 @@ Response:
     "notCheckedInCount": 2,
     "lateCount": 1,
     "onLeaveCount": 1,
-    "failedAttemptCount": 1
+    "failedAttemptCount": 1,
+    "previousDayOpenCount": 1
   },
   "items": [
     {
@@ -890,13 +906,19 @@ Response:
       "display": {
         "phase": "working",
         "flags": [],
-        "activeExceptions": [],
+        "activeExceptions": ["previous_day_checkout_missing"],
         "nextAction": {
-          "type": "clock_out",
+          "type": "resolve_previous_day_checkout",
           "relatedRequestId": null
         }
       },
       "latestFailedAttempt": null,
+      "previousDayOpenRecord": {
+        "date": "2026-04-10",
+        "clockInAt": "2026-04-10T08:56:00+09:00",
+        "clockOutAt": null,
+        "expectedClockOutAt": "2026-04-10T18:00:00+09:00"
+      },
       "manualRequest": null
     }
   ]
@@ -908,10 +930,11 @@ Response notes:
 - This endpoint is the default same-day operations surface for `/admin/attendance`, not a general-purpose historical ledger.
 - `latestFailedAttempt` is `null` unless the employee has an unresolved failed attempt that still matters operationally.
 - When present, `latestFailedAttempt` reuses the shared `Attendance Attempt` shape but must keep `status = failed` and a non-empty `failureReason`; its `date` identifies the target workday even if `attemptedAt` falls on the next calendar date during overnight prior-workday writeback.
-- `manualRequest` is `null` unless a `pending`, `revision_requested`, or `rejected` manual attendance request still matters for that employee's same-date attendance state.
+- `previousDayOpenRecord` is `null` unless the prior workday is still open. A populated prior-day `clockOutAt` must not derive `previous_day_checkout_missing`.
+- `manualRequest` is `null` unless a `pending`, `revision_requested`, or `rejected` manual attendance request still matters for that employee's current attendance state; when present it may target the requested workday or the prior workday during carry-over handling.
 - Consumers should treat `manualRequest` as a compact row-level projection rather than a full request detail payload. It appears on `GET /api/attendance/me`, `GET /api/attendance/me/history`, and `GET /api/admin/attendance/today`, but history rows restrict it to same-date `pending` requests only.
 - If an employee edits or withdraws a pending manual request before review, the row should refresh from the latest projection. Approved manual requests should disappear from this embedded surface once canonical attendance writeback completes.
-- No-record employees must still appear when they count toward today's expected workday and their current operational state already needs attention, such as after the adjusted expected start or when a failed attempt or current manual request is still active.
+- No-record employees must still appear when they count toward today's expected workday and their current operational state already needs attention, such as after the adjusted expected start or when a failed attempt, carry-over issue, or current manual request is still active.
 
 ### `GET /api/admin/attendance/list?from=&to=&name=`
 
@@ -978,6 +1001,7 @@ Response notes:
 
 - This endpoint backs the secondary history review mode for `/admin/attendance`, not the default today-first operations surface.
 - When present, `latestFailedAttempt` still represents a failed attempt only, so `status` must be `failed`.
+- Historical rows may still derive `previous_day_checkout_missing` on the current row when an older workday remains open and still governs the selected day.
 - Historical rows stay date-scoped and do not embed the compact `manualRequest` projection used by `GET /api/admin/attendance/today`.
 
 ## Request Review Endpoints

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -44,6 +44,7 @@ The runtime meaning of those concepts over time lives in `docs/attendance-operat
 - `attempt_failed`
 - `not_checked_in`
 - `absent`
+- `previous_day_checkout_missing`
 - `leave_work_conflict`
 - `manual_request_pending`
 - `manual_request_rejected`
@@ -53,6 +54,7 @@ The runtime meaning of those concepts over time lives in `docs/attendance-operat
 - `clock_in`
 - `clock_out`
 - `submit_manual_request`
+- `resolve_previous_day_checkout`
 - `review_request_status`
 - `review_leave_conflict`
 - `wait`
@@ -397,6 +399,24 @@ Important rules:
 - `not_checked_in` is a real-time expected-but-missing exception, not a finalized absence.
 - `absent` is a finalized derived interpretation after day-close.
 - Once `absent` is finalized for a still-missing workday, the next employee attendance action becomes `submit_manual_request` instead of `clock_in`.
+- `previous_day_checkout_missing` uses the `09:00` carry-over cutoff in the workday timezone carried by the attendance facts.
+- `previous_day_checkout_missing` applies only while the prior workday still has no `clockOutAt`.
+
+### Previous Day Open Record Summary
+
+Represents the prior workday that remains open because checkout is still missing.
+This summary is derived from `Attendance Record` and `Expected Workday`, then surfaced as a high-priority operational exception.
+
+Expected fields:
+
+- previous work date
+- prior clock-in fact
+- missing checkout state
+- expected checkout time
+
+Important rule:
+
+- This summary only drives `previous_day_checkout_missing` while the prior workday remains open, meaning `clockOutAt` is still `null`.
 - An unresolved missing checkout from an earlier workday remains a row-local issue on that workday instead of becoming a later-day exception type.
 
 ### Admin Attendance Summary
@@ -410,6 +430,7 @@ Expected fields:
 - `lateCount`
 - `onLeaveCount`
 - `failedAttemptCount`
+- `previousDayOpenCount`
 
 ### Admin Request Queue Item
 

--- a/docs/feature-requirements.md
+++ b/docs/feature-requirements.md
@@ -111,10 +111,12 @@ Validation and policy topics that must stay aligned with narrower contract docum
 
 Required UI:
 
-- a default today-first operations mode that opens in `today`, `exception-first`, and `entire team`
-- today summary cards for checked-in, not checked-in, late, on-leave, and failed-attempt counts
-- a grouped exception-first operations queue for today rather than a full-team default table
-- an exception-first team list that still includes employees with no successful attendance record for the day once their current operational state becomes relevant
+- a default today-first operations mode that renders the page in this order: exception table, one-row summary cards, then full team ledger
+- a top exception table that aggregates unresolved employee-surface exceptions for the day instead of using a left rail, while leaving routine historical `지각` and `조퇴` marks in history or ledger context
+- one horizontal row of summary cards labeled `근무중`, `출근 전`, `지각`, `조퇴`, `연차`, `반차`, and `시간차`
+- a full team ledger with selectable `기본`, `근무상태별`, and `근태상태별` views using the same underlying data
+- an exception-table-first team list that still includes employees with no successful attendance record for the day once their current operational state becomes relevant
+- visible carry-over warnings for employees whose previous workday is still open because checkout is missing
 - visibility into failed attendance attempts, leave-work conflicts, and compact current manual attendance request state where applicable
 - a secondary history review mode inside the same route with page-local controls for search and selected date range
 - a default history range of the last 7 days including today when the admin enters history mode without explicit URL state
@@ -125,13 +127,15 @@ Implementation concerns that must stay aligned with narrower contract documents:
 - whether department filtering is required in the first implementation pass
 - history review should remain a secondary mode inside `/admin/attendance` rather than replacing the today-first default entry behavior
 - mode, date range, and search state should remain URL-shareable when they affect admin attendance queries
-- action-needed summary cards and today queue rows should derive from the same date-level facts so counts never drift from the queue
-- contextual summary cards such as checked-in and on-leave should use the same date-level facts as the exception queue, but they do not need 1:1 queue-row parity because the default today surface remains exception-first
+- the today exception table, one-row summary cards, and ledger view groupings should all derive from the same date-level facts so counts and group membership never drift
+- these are presentation-only projections; the public API contract remains unchanged
 
 Edge cases to keep visible during implementation:
 
-- a no-record employee becomes visible in the today operations queue after the adjusted expected start passes even if no attendance row has been created yet
-- a no-record employee with an unresolved failed attempt or current manual request may become queue-visible before a simple missing check-in warning would apply
+- a no-record employee becomes visible in the top exception table after the adjusted expected start passes even if no attendance row has been created yet
+- a no-record employee with an unresolved failed attempt, carry-over problem, or current manual request may become table-visible before a simple missing check-in warning would apply
+- finalized `결근` rows in the top exception table should read with the same high-risk warning treatment as missing-record rows
+- a prior-workday carry-over correction request may remain embedded on a today row when it still explains the employee's current operational state, and the target date must stay visible
 - an approved manual attendance correction must clear from the today embedded request state once canonical attendance writeback finishes
 
 ### Request Review: `/admin/attendance/requests`

--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -72,16 +72,19 @@ For the attendance-shell refresh, the provided Figma frame is the higher-priorit
 - On employee `/attendance`, if a pending or review-state manual request already covers a rail target date, let that request-status surface replace duplicate generic correction surfaces for the same target in the rail. Keep unrelated exception meanings such as leave-work conflict visible.
 - Historical `정정 요청됨` rail cards should use a yellow warning treatment, action-specific titles such as `출근 시간 정정 요청을 확인하고 있어요`, `퇴근 시간 정정 요청을 확인하고 있어요`, or `근무 기록 정정 요청을 확인하고 있어요`, visible target-date meta, and the CTA `요청 보기`.
 - Keep destructive historical issue cards such as `정정 필요` or `결근` above yellow pending-request cards in the rail ordering.
-- Action-needed admin summary cards should match the queue rows derived from the same fact set rather than drifting into approximate counts.
-- Contextual admin summary cards such as checked-in and on-leave should reuse the same fact set, but they must not be turned into queue-driving pseudo-exceptions just to force 1:1 row parity on the default today surface.
-- No-record employees should enter the admin queue only when their current operational state needs attention, not as all-day placeholder rows.
+- Do not use a left exception rail on `/admin/attendance`; aggregate unresolved employee-surface exceptions in the top exception table instead.
+- Use one horizontal summary row on `/admin/attendance` with `근무중`, `출근 전`, `지각`, `조퇴`, `연차`, `반차`, and `시간차`; these cards are context, not queue entries.
+- Keep the `/admin/attendance` top exception table focused on unresolved operational exceptions. Do not promote routine historical `지각` or `조퇴` rows into that table when they no longer drive current action.
+- The `/admin/attendance` ledger should expose `기본`, `근무상태별`, and `근태상태별` view toggles, and each grouping must come from the same underlying facts.
+- No-record employees should enter the top exception table only when their current operational state needs attention, not as all-day placeholder rows.
+- Use the same danger-family row tint for `/admin/attendance` top-table `결근` rows that you use for other missing-record rows such as `출근 누락` or `퇴근 누락`.
 - Do not make hover the primary disclosure mechanism for any important reason, exception, or next action.
 - Use `docs/leave-conflict-policy.md` for the severity and meaning of leave-request conflict states; this file owns only how those states are surfaced.
 
 ## Exception Priority
 
 - Employee attendance views should prioritize: unresolved failed attempt, active derived manual request summary, leave-work conflict, same-day expected-but-missing check-in, and then lower-risk history states.
-- Admin attendance views should prioritize exceptions over aggregate comfort metrics. The default today queue should group unresolved failed attempts, request-related exceptions, and then simpler missing or late cases so unresolved operational risk is easier to notice than nominal counts.
+- Admin attendance views should prioritize exceptions over aggregate comfort metrics. The top exception table should group carry-over issues, unresolved failed attempts, request-related exceptions, and then simpler missing or absence cases so unresolved operational risk is easier to notice than nominal counts.
 - Approved leave must suppress generic missing-check-in warnings for the covered period, but a later actual attendance fact on the same leave-covered day must surface as a leave-work conflict.
 
 ## Notification Surface Taxonomy

--- a/lib/attendance/derivation.ts
+++ b/lib/attendance/derivation.ts
@@ -7,6 +7,7 @@ import type {
   AttendanceRecord,
   AttendanceSurfaceManualRequestResource,
   ExpectedWorkday,
+  PreviousDayOpenRecord,
 } from "@/lib/contracts/shared";
 
 type DeriveAttendanceDisplayInput = {
@@ -14,6 +15,7 @@ type DeriveAttendanceDisplayInput = {
   expectedWorkday: ExpectedWorkday;
   record: AttendanceRecord | null;
   attempts: AttendanceAttempt[];
+  previousDayOpenRecord?: PreviousDayOpenRecord | null;
   manualRequest?: AttendanceSurfaceManualRequestResource | null;
 };
 
@@ -25,6 +27,47 @@ type DeriveAdminAttendanceSummaryItem = {
 
 function toDate(value: string | null): Date | null {
   return value ? new Date(value) : null;
+}
+
+function getOffset(isoDateTime: string): string {
+  return isoDateTime.endsWith("Z") ? "Z" : isoDateTime.slice(-6);
+}
+
+function getOffsetMinutes(isoDateTime: string): number {
+  if (isoDateTime.endsWith("Z")) {
+    return 0;
+  }
+
+  const sign = isoDateTime.slice(-6, -5) === "-" ? -1 : 1;
+  const hours = Number.parseInt(isoDateTime.slice(-5, -3), 10);
+  const minutes = Number.parseInt(isoDateTime.slice(-2), 10);
+
+  return sign * (hours * 60 + minutes);
+}
+
+function buildDateTime(
+  date: string,
+  time: string,
+  referenceDateTime: string,
+): string {
+  return `${date}T${time}${getOffset(referenceDateTime)}`;
+}
+
+function getDateInReferenceOffset(
+  isoDateTime: string,
+  referenceDateTime: string,
+): string {
+  const date = toDate(isoDateTime);
+
+  if (date === null) {
+    return isoDateTime.slice(0, 10);
+  }
+
+  const offsetMinutes = getOffsetMinutes(referenceDateTime);
+
+  return new Date(date.getTime() + offsetMinutes * 60_000)
+    .toISOString()
+    .slice(0, 10);
 }
 
 function hasLaterSuccessfulAttempt(
@@ -101,6 +144,7 @@ function deriveActiveExceptions({
   expectedWorkday,
   record,
   attempts,
+  previousDayOpenRecord,
   manualRequest,
   phase,
 }: DeriveAttendanceDisplayInput & {
@@ -108,8 +152,27 @@ function deriveActiveExceptions({
 }): AttendanceExceptionType[] {
   const activeExceptions: AttendanceExceptionType[] = [];
   const currentTime = toDate(now);
+  const carryOverReferenceDateTime =
+    previousDayOpenRecord?.expectedClockOutAt ??
+    previousDayOpenRecord?.clockInAt ??
+    now;
+  const currentDate = getDateInReferenceOffset(now, carryOverReferenceDateTime);
+  const carryOverCutoff = toDate(
+    buildDateTime(currentDate, "09:00:00", carryOverReferenceDateTime),
+  );
   const adjustedClockInAt = toDate(expectedWorkday.adjustedClockInAt);
   const adjustedClockOutAt = toDate(expectedWorkday.adjustedClockOutAt);
+
+  if (
+    previousDayOpenRecord !== null &&
+    previousDayOpenRecord !== undefined &&
+    previousDayOpenRecord.clockOutAt === null &&
+    currentTime !== null &&
+    carryOverCutoff !== null &&
+    currentTime.getTime() >= carryOverCutoff.getTime()
+  ) {
+    activeExceptions.push("previous_day_checkout_missing");
+  }
 
   const latestOperationalFailure = attempts.findLast(
     (attempt) =>
@@ -168,6 +231,13 @@ function deriveNextAction(
   phase: AttendancePhase,
   activeExceptions: AttendanceExceptionType[],
 ): AttendanceDisplay["nextAction"] {
+  if (activeExceptions.includes("previous_day_checkout_missing")) {
+    return {
+      type: "resolve_previous_day_checkout",
+      relatedRequestId: null,
+    };
+  }
+
   if (
     activeExceptions.includes("manual_request_pending") ||
     activeExceptions.includes("manual_request_rejected")

--- a/lib/contracts/admin-attendance.ts
+++ b/lib/contracts/admin-attendance.ts
@@ -8,6 +8,7 @@ import {
   employeeSummarySchema,
   expectedWorkdaySchema,
   failedAttendanceAttemptSchema,
+  previousDayOpenRecordSchema,
 } from "@/lib/contracts/shared";
 
 const adminAttendanceTodayItemSchema = z.object({
@@ -16,6 +17,7 @@ const adminAttendanceTodayItemSchema = z.object({
   todayRecord: attendanceRecordSchema.nullable(),
   display: attendanceDisplaySchema,
   latestFailedAttempt: failedAttendanceAttemptSchema.nullable(),
+  previousDayOpenRecord: previousDayOpenRecordSchema.nullable(),
   manualRequest: attendanceSurfaceManualRequestResourceSchema.nullable(),
 });
 
@@ -36,6 +38,7 @@ export const adminAttendanceTodayResponseSchema = z.object({
     lateCount: z.number(),
     onLeaveCount: z.number(),
     failedAttemptCount: z.number(),
+    previousDayOpenCount: z.number(),
   }),
   items: z.array(adminAttendanceTodayItemSchema),
 });

--- a/lib/contracts/shared.ts
+++ b/lib/contracts/shared.ts
@@ -16,6 +16,7 @@ export const attendanceExceptionTypeSchema = z.enum([
   "attempt_failed",
   "not_checked_in",
   "absent",
+  "previous_day_checkout_missing",
   "leave_work_conflict",
   "manual_request_pending",
   "manual_request_rejected",
@@ -24,6 +25,7 @@ export const nextActionTypeSchema = z.enum([
   "clock_in",
   "clock_out",
   "submit_manual_request",
+  "resolve_previous_day_checkout",
   "review_request_status",
   "review_leave_conflict",
   "wait",
@@ -135,6 +137,13 @@ export const attendanceDisplaySchema = z.object({
   flags: z.array(attendanceFlagSchema),
   activeExceptions: z.array(attendanceExceptionTypeSchema),
   nextAction: attendanceDisplayNextActionSchema,
+});
+
+export const previousDayOpenRecordSchema = z.object({
+  date: apiDateSchema,
+  clockInAt: apiDateTimeSchema,
+  clockOutAt: apiDateTimeSchema.nullable(),
+  expectedClockOutAt: apiDateTimeSchema.nullable(),
 });
 
 export const leaveBalanceSchema = z.object({
@@ -725,6 +734,7 @@ export type AttendanceDisplayNextAction = z.infer<
   typeof attendanceDisplayNextActionSchema
 >;
 export type AttendanceDisplay = z.infer<typeof attendanceDisplaySchema>;
+export type PreviousDayOpenRecord = z.infer<typeof previousDayOpenRecordSchema>;
 export type LeaveBalance = z.infer<typeof leaveBalanceSchema>;
 export type CompanyEvent = z.infer<typeof companyEventSchema>;
 export type LeaveConflict = z.infer<typeof leaveConflictSchema>;

--- a/lib/repositories/attendance.ts
+++ b/lib/repositories/attendance.ts
@@ -17,6 +17,7 @@ import type {
   ExpectedWorkday,
   FailedAttendanceAttempt,
   LeaveCoverage,
+  PreviousDayOpenRecord,
 } from "@/lib/contracts/shared";
 import { resolveEffectiveApprovedLeaveRequests } from "@/lib/repositories/leave-conflicts";
 import { buildLeaveInterval } from "@/lib/repositories/leave-intervals";
@@ -62,8 +63,13 @@ type AttendanceSurfaceRow = {
   attempts: AttendanceAttempt[];
   display: ReturnType<typeof deriveAttendanceDisplay>;
   latestFailedAttempt: FailedAttendanceAttempt | null;
+  previousDayOpenRecord: PreviousDayOpenRecord | null;
   manualRequest: AttendanceSurfaceManualRequestResource | null;
 };
+
+type BuildAttendanceSurfaceRowOptions = Readonly<{
+  includeCarryOver?: boolean;
+}>;
 
 function assertEmployeeExists(
   world: AttendanceRepositoryWorld,
@@ -254,6 +260,45 @@ function resolveAttendanceRecord(
   );
 }
 
+function resolvePreviousDayOpenRecord(
+  world: AttendanceRepositoryWorld,
+  employeeId: string,
+  date: string,
+  now: string,
+) {
+  const openRecords = world.attendanceRecords.filter(
+    (record) =>
+      record.employeeId === employeeId &&
+      record.date < date &&
+      record.clockInAt !== null &&
+      record.clockOutAt === null,
+  );
+  const latestOpenRecord = openRecords.sort((left, right) =>
+    compareDates(right.date, left.date),
+  )[0];
+
+  if (latestOpenRecord === undefined || latestOpenRecord.clockInAt === null) {
+    return null;
+  }
+
+  const cutoff = buildDateTime(date, "09:00:00", latestOpenRecord.clockInAt);
+
+  if (new Date(now).getTime() < new Date(cutoff).getTime()) {
+    return null;
+  }
+
+  return {
+    date: latestOpenRecord.date,
+    clockInAt: latestOpenRecord.clockInAt,
+    clockOutAt: latestOpenRecord.clockOutAt,
+    expectedClockOutAt: buildDateTime(
+      latestOpenRecord.date,
+      "18:00:00",
+      latestOpenRecord.clockInAt,
+    ),
+  } satisfies PreviousDayOpenRecord;
+}
+
 function hasLaterSuccessfulAttempt(
   failedAttempt: AttendanceAttempt,
   attempts: AttendanceAttempt[],
@@ -273,11 +318,23 @@ function resolveOperationalAttempts(
   world: AttendanceRepositoryWorld,
   employeeId: string,
   date: string,
+  previousDayOpenRecord: PreviousDayOpenRecord | null,
 ) {
   const relevantAttempts = world.attendanceAttempts
-    .filter(
-      (attempt) => attempt.employeeId === employeeId && attempt.date === date,
-    )
+    .filter((attempt) => {
+      if (attempt.employeeId !== employeeId) {
+        return false;
+      }
+
+      if (attempt.date === date) {
+        return true;
+      }
+
+      return (
+        previousDayOpenRecord !== null &&
+        attempt.date === previousDayOpenRecord.date
+      );
+    })
     .map(toAttendanceAttempt);
 
   return relevantAttempts
@@ -319,19 +376,25 @@ function buildAttendanceSurfaceRow(
   employeeId: string,
   date: string,
   now: string,
+  options: BuildAttendanceSurfaceRowOptions = {},
 ): AttendanceSurfaceRow {
   const employee = assertEmployeeExists(world, employeeId);
   const expectedWorkday = resolveExpectedWorkday(world, employeeId, date, now);
   const record = resolveAttendanceRecord(world, employeeId, date);
+  const previousDayOpenRecord = options.includeCarryOver
+    ? resolvePreviousDayOpenRecord(world, employeeId, date, now)
+    : null;
   const operationalAttempts = resolveOperationalAttempts(
     world,
     employeeId,
     date,
+    previousDayOpenRecord,
   );
   const manualRequest = resolveAttendanceSurfaceManualRequest(
     world,
     employeeId,
     date,
+    previousDayOpenRecord,
   );
 
   return {
@@ -349,9 +412,11 @@ function buildAttendanceSurfaceRow(
       expectedWorkday,
       record,
       attempts: operationalAttempts,
+      previousDayOpenRecord,
       manualRequest,
     }),
     latestFailedAttempt: resolveLatestFailedAttempt(operationalAttempts),
+    previousDayOpenRecord,
     manualRequest,
   };
 }
@@ -359,6 +424,7 @@ function buildAttendanceSurfaceRow(
 function isAdminTodayItemRelevant(row: AttendanceSurfaceRow) {
   return (
     row.record !== null ||
+    row.previousDayOpenRecord !== null ||
     row.latestFailedAttempt !== null ||
     row.manualRequest !== null ||
     row.expectedWorkday.leaveCoverage !== null ||
@@ -369,6 +435,7 @@ function isAdminTodayItemRelevant(row: AttendanceSurfaceRow) {
 function isAdminListRowRelevant(row: AttendanceSurfaceRow) {
   return (
     row.record !== null ||
+    row.previousDayOpenRecord !== null ||
     row.latestFailedAttempt !== null ||
     row.manualRequest !== null ||
     row.expectedWorkday.leaveCoverage !== null ||
@@ -484,7 +551,9 @@ export function getAdminAttendanceToday(
   input: AdminAttendanceTodayInput,
 ): AdminAttendanceTodayResponse {
   const allRows = world.employees.map((employee) =>
-    buildAttendanceSurfaceRow(world, employee.id, input.date, input.now),
+    buildAttendanceSurfaceRow(world, employee.id, input.date, input.now, {
+      includeCarryOver: true,
+    }),
   );
 
   const summary = deriveAdminAttendanceSummary(
@@ -499,23 +568,27 @@ export function getAdminAttendanceToday(
     .filter(isAdminTodayItemRelevant)
     .sort((left, right) => {
       const priority = (row: AttendanceSurfaceRow) => {
-        if (row.latestFailedAttempt !== null) {
+        if (row.previousDayOpenRecord !== null) {
           return 0;
         }
 
-        if (row.manualRequest !== null) {
+        if (row.latestFailedAttempt !== null) {
           return 1;
         }
 
-        if (row.display.activeExceptions.includes("not_checked_in")) {
+        if (row.manualRequest !== null) {
           return 2;
         }
 
-        if (row.display.activeExceptions.includes("leave_work_conflict")) {
+        if (row.display.activeExceptions.includes("not_checked_in")) {
           return 3;
         }
 
-        return 4;
+        if (row.display.activeExceptions.includes("leave_work_conflict")) {
+          return 4;
+        }
+
+        return 5;
       };
 
       const priorityDelta = priority(left) - priority(right);
@@ -532,12 +605,18 @@ export function getAdminAttendanceToday(
       todayRecord: row.record,
       display: row.display,
       latestFailedAttempt: row.latestFailedAttempt,
+      previousDayOpenRecord: row.previousDayOpenRecord,
       manualRequest: row.manualRequest,
     }));
 
   return {
     date: input.date,
-    summary,
+    summary: {
+      ...summary,
+      previousDayOpenCount: allRows.filter(
+        (row) => row.previousDayOpenRecord !== null,
+      ).length,
+    },
     items,
   };
 }
@@ -554,7 +633,9 @@ export function getAdminAttendanceList(
   const rows = getRangeDates(input.from, input.to)
     .flatMap((date) =>
       world.employees.map((employee) =>
-        buildAttendanceSurfaceRow(world, employee.id, date, input.now),
+        buildAttendanceSurfaceRow(world, employee.id, date, input.now, {
+          includeCarryOver: true,
+        }),
       ),
     )
     .filter((row) => {

--- a/lib/repositories/manual-attendance.ts
+++ b/lib/repositories/manual-attendance.ts
@@ -405,6 +405,7 @@ export function resolveAttendanceSurfaceManualRequest(
   world: CanonicalSeedWorld,
   employeeId: string,
   date: string,
+  previousDayOpenRecord: { date: string } | null = null,
 ) {
   const buildSurfaceResourceForDate = (targetDate: string) => {
     const chainRequests = world.manualAttendanceRequests
@@ -432,6 +433,16 @@ export function resolveAttendanceSurfaceManualRequest(
 
     return toAttendanceSurfaceResource(surfacedRequest, projection);
   };
+
+  if (previousDayOpenRecord !== null) {
+    const carryOverResource = buildSurfaceResourceForDate(
+      previousDayOpenRecord.date,
+    );
+
+    if (carryOverResource !== null) {
+      return carryOverResource;
+    }
+  }
 
   return buildSurfaceResourceForDate(date);
 }

--- a/tests/integration/admin-attendance-route.test.tsx
+++ b/tests/integration/admin-attendance-route.test.tsx
@@ -35,11 +35,12 @@ describe("admin attendance route helpers", () => {
     vi.mocked(fetchAdminAttendanceToday).mockResolvedValueOnce({
       date: "2026-04-13",
       summary: {
-        checkedInCount: 1,
-        notCheckedInCount: 1,
-        lateCount: 0,
-        onLeaveCount: 0,
-        failedAttemptCount: 0,
+        checkedInCount: 9,
+        notCheckedInCount: 2,
+        lateCount: 1,
+        onLeaveCount: 1,
+        failedAttemptCount: 1,
+        previousDayOpenCount: 1,
       },
       items: [],
     });
@@ -56,6 +57,7 @@ describe("admin attendance route helpers", () => {
     });
     expect(fetchAdminAttendanceList).not.toHaveBeenCalled();
     expect(result.todayResponse?.date).toBe("2026-04-13");
+    expect(result.todayExceptionRows).toEqual([]);
     expect(result.historyResponse).toBeUndefined();
   });
 
@@ -93,6 +95,7 @@ describe("admin attendance route helpers", () => {
     );
     expect(fetchAdminAttendanceToday).not.toHaveBeenCalled();
     expect(result.historyResponse?.filters.name).toBe("alex");
+    expect(result.todayExceptionRows).toBeUndefined();
     expect(result.todayResponse).toBeUndefined();
   });
 

--- a/tests/integration/admin-attendance-workspace.test.tsx
+++ b/tests/integration/admin-attendance-workspace.test.tsx
@@ -6,6 +6,7 @@ import {
   type AdminAttendanceUrlState,
   normalizeAdminAttendanceUrlState,
 } from "@/app/(erp)/(admin)/admin/attendance/_lib/page-state";
+import { buildAdminAttendanceTodayExceptionRows } from "@/app/(erp)/(admin)/admin/attendance/_lib/today-exception-rows";
 import { createSeedRepository } from "@/lib/repositories";
 import { canonicalSeedWorld } from "@/lib/seed/world";
 
@@ -26,11 +27,9 @@ function createState(search = ""): AdminAttendanceUrlState {
   return normalizeAdminAttendanceUrlState(new URLSearchParams(search));
 }
 
-function getRowByEmployeeNameAndDate(name: string, date: string) {
-  const cell = screen
-    .getAllByText(name)
-    .find((candidate) => candidate.closest("tr")?.textContent?.includes(date));
-  const row = cell?.closest("tr");
+function getRowByEmployeeName(name: string) {
+  const cell = screen.getByText(name);
+  const row = cell.closest("tr");
 
   expect(row).not.toBeNull();
 
@@ -41,6 +40,12 @@ const repository = createSeedRepository({
   world: canonicalSeedWorld,
 });
 
+function createTodayResponse() {
+  return repository.getAdminAttendanceToday({
+    date: canonicalSeedWorld.baselineDate,
+  });
+}
+
 describe("AdminAttendanceWorkspace", () => {
   beforeEach(() => {
     pathnameValue = "/admin/attendance";
@@ -48,72 +53,84 @@ describe("AdminAttendanceWorkspace", () => {
     replaceMock.mockReset();
   });
 
-  it("renders today summary cards and the grouped exception-first queue", () => {
-    const neutralOnTimeEmployee = repository
-      .getAdminAttendanceToday({
-        date: canonicalSeedWorld.baselineDate,
-      })
-      .items.find(
-        (item) =>
-          item.todayRecord !== null &&
-          item.latestFailedAttempt === null &&
-          item.manualRequest === null &&
-          item.display.activeExceptions.length === 0 &&
-          item.display.flags.length === 0,
-      )?.employee.name;
+  it("renders the exception table, one-row summary cards, and full team ledger", () => {
+    const todayResponse = createTodayResponse();
 
     render(
       <AdminAttendanceWorkspace
         state={createState()}
-        todayResponse={repository.getAdminAttendanceToday({
-          date: canonicalSeedWorld.baselineDate,
-        })}
+        todayExceptionRows={buildAdminAttendanceTodayExceptionRows(
+          todayResponse,
+        )}
+        todayResponse={todayResponse}
       />,
     );
 
-    expect(screen.getByText("출근 완료")).toBeInTheDocument();
-    expect(screen.getByText("출근 전")).toBeInTheDocument();
+    expect(screen.getByText("누적 예외")).toBeInTheDocument();
+    expect(screen.getAllByText("근무중").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("출근 전").length).toBeGreaterThan(0);
     expect(screen.getAllByText("지각").length).toBeGreaterThan(0);
-    expect(screen.getByText("휴가")).toBeInTheDocument();
-    expect(screen.getByText("출결 시도 실패")).toBeInTheDocument();
-
-    expect(screen.getByText("실패한 시도")).toBeInTheDocument();
-    expect(screen.getByText("오늘 확인 필요")).toBeInTheDocument();
-    const noRecordRow = screen.getAllByText("출근 기록 없음")[0]?.closest("li");
+    expect(screen.getAllByText("조퇴").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("연차").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("반차").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("시간차").length).toBeGreaterThan(0);
+    expect(screen.getByText("전체 팀 장부")).toBeInTheDocument();
+    expect(screen.getAllByText("전날 미퇴근").length).toBeGreaterThan(0);
+    const noRecordRow = screen.getAllByText("Nari Oh")[0]?.closest("tr");
     expect(noRecordRow).not.toBeNull();
     expect(noRecordRow).toHaveTextContent("출근 기록 없음");
-    expect(noRecordRow).toHaveTextContent("기록 없음");
-
-    if (neutralOnTimeEmployee !== undefined) {
-      expect(screen.queryByText(neutralOnTimeEmployee)).not.toBeInTheDocument();
-    }
+    expect(noRecordRow).toHaveTextContent("Finance");
+    expect(screen.getAllByText("Minji Park").length).toBeGreaterThan(0);
   });
 
-  it("shows the governing review comment for the pending manual-request projection", () => {
+  it("shows the prior-workday target date for the carry-over row", () => {
+    const todayResponse = createTodayResponse();
+
     render(
       <AdminAttendanceWorkspace
         state={createState()}
-        todayResponse={repository.getAdminAttendanceToday({
-          date: canonicalSeedWorld.baselineDate,
-        })}
+        todayExceptionRows={buildAdminAttendanceTodayExceptionRows(
+          todayResponse,
+        )}
+        todayResponse={todayResponse}
       />,
     );
 
-    expect(screen.getByText("Hyunwoo Baek")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Please submit a follow-up if the beacon issue continues.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText("Minji Park").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("2026-04-10").length).toBeGreaterThan(0);
+  });
+
+  it("keeps failed-attempt rows visible in the exception table", () => {
+    const todayResponse = createTodayResponse();
+
+    render(
+      <AdminAttendanceWorkspace
+        state={createState()}
+        todayExceptionRows={buildAdminAttendanceTodayExceptionRows(
+          todayResponse,
+        )}
+        todayResponse={todayResponse}
+      />,
+    );
+
+    const pendingRequestRow = screen
+      .getAllByText("Hyunwoo Baek")[0]
+      ?.closest("tr");
+
+    expect(pendingRequestRow).not.toBeNull();
+    expect(pendingRequestRow).toHaveTextContent("시도 실패");
   });
 
   it("switches to history mode with the default date range in the URL", () => {
+    const todayResponse = createTodayResponse();
+
     render(
       <AdminAttendanceWorkspace
         state={createState()}
-        todayResponse={repository.getAdminAttendanceToday({
-          date: canonicalSeedWorld.baselineDate,
-        })}
+        todayExceptionRows={buildAdminAttendanceTodayExceptionRows(
+          todayResponse,
+        )}
+        todayResponse={todayResponse}
       />,
     );
 
@@ -126,12 +143,15 @@ describe("AdminAttendanceWorkspace", () => {
   });
 
   it("switches tabs from the keyboard through a single replace path", () => {
+    const todayResponse = createTodayResponse();
+
     render(
       <AdminAttendanceWorkspace
         state={createState()}
-        todayResponse={repository.getAdminAttendanceToday({
-          date: canonicalSeedWorld.baselineDate,
-        })}
+        todayExceptionRows={buildAdminAttendanceTodayExceptionRows(
+          todayResponse,
+        )}
+        todayResponse={todayResponse}
       />,
     );
 
@@ -199,27 +219,23 @@ describe("AdminAttendanceWorkspace", () => {
     expect(screen.getByDisplayValue("2026-04-07")).toBeInTheDocument();
     expect(screen.getByDisplayValue("2026-04-13")).toBeInTheDocument();
     expect(
-      screen.getByText("조건에 맞는 근태 이력이 없어요."),
+      screen.getByText("조건에 맞는 근태 이력이 없어요"),
     ).toBeInTheDocument();
   });
 
   it("renders explicit seeded history exception labels without today-copy phrasing", () => {
     render(
       <AdminAttendanceWorkspace
-        state={createState("?mode=history&from=2026-04-10&to=2026-04-13")}
+        state={createState("?mode=history&from=2026-04-13&to=2026-04-13")}
         historyResponse={repository.getAdminAttendanceList({
-          from: "2026-04-10",
+          from: "2026-04-13",
           to: "2026-04-13",
         })}
       />,
     );
 
-    expect(
-      getRowByEmployeeNameAndDate("Minji Park", "2026-04-10"),
-    ).toHaveTextContent("퇴근 누락");
-    expect(
-      getRowByEmployeeNameAndDate("Hyunwoo Baek", "2026-04-13"),
-    ).toHaveTextContent("시도 실패");
+    expect(getRowByEmployeeName("Minji Park")).toHaveTextContent("전날 미퇴근");
+    expect(getRowByEmployeeName("Hyunwoo Baek")).toHaveTextContent("시도 실패");
     expect(
       screen.queryByText("오늘 지각으로 기록됐어요."),
     ).not.toBeInTheDocument();
@@ -229,6 +245,7 @@ describe("AdminAttendanceWorkspace", () => {
     render(
       <AdminAttendanceWorkspace
         state={createState()}
+        todayExceptionRows={[]}
         todayResponse={{
           date: canonicalSeedWorld.baselineDate,
           summary: {
@@ -237,14 +254,50 @@ describe("AdminAttendanceWorkspace", () => {
             lateCount: 0,
             onLeaveCount: 0,
             failedAttemptCount: 0,
+            previousDayOpenCount: 0,
           },
           items: [],
         }}
       />,
     );
 
-    expect(
-      screen.getByText("오늘 바로 확인할 근태가 없어요."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("지금 누적 예외가 없어요")).toBeInTheDocument();
+    expect(screen.getByText("검색 결과가 없어요")).toBeInTheDocument();
+  });
+
+  it("uses the danger tint for absent rows in the exception table", () => {
+    render(
+      <AdminAttendanceWorkspace
+        state={createState()}
+        todayExceptionRows={[
+          {
+            department: "Operations",
+            detail: "결근 상태가 남아 있어요",
+            employeeId: "emp_absent",
+            employeeName: "Absent Employee",
+            exceptionType: "결근",
+            id: "exception-absent-row",
+            referenceDate: "2026-04-10",
+            specialNote: "-",
+          },
+        ]}
+        todayResponse={{
+          date: canonicalSeedWorld.baselineDate,
+          summary: {
+            checkedInCount: 0,
+            notCheckedInCount: 0,
+            lateCount: 0,
+            onLeaveCount: 0,
+            failedAttemptCount: 0,
+            previousDayOpenCount: 0,
+          },
+          items: [],
+        }}
+      />,
+    );
+
+    expect(getRowByEmployeeName("Absent Employee")).toHaveClass(
+      "bg-status-danger-soft/28",
+    );
   });
 });

--- a/tests/unit/admin-attendance-page-state.test.ts
+++ b/tests/unit/admin-attendance-page-state.test.ts
@@ -74,6 +74,7 @@ function makeTodayItem(
       },
     },
     latestFailedAttempt: null,
+    previousDayOpenRecord: null,
     manualRequest: null,
     ...overrides,
   };
@@ -161,6 +162,30 @@ describe("groupAdminAttendanceTodayRows", () => {
     const grouped = groupAdminAttendanceTodayRows([
       makeTodayItem({
         employee: {
+          id: "emp_101",
+          name: "Prev Day Open",
+          department: "Operations",
+        },
+        previousDayOpenRecord: {
+          date: "2026-04-12",
+          clockInAt: "2026-04-12T09:00:00+09:00",
+          clockOutAt: null,
+          expectedClockOutAt: "2026-04-12T18:00:00+09:00",
+        },
+        latestFailedAttempt: {
+          id: "failed_attempt",
+          date: "2026-04-13",
+          action: "clock_in",
+          attemptedAt: "2026-04-13T09:05:00+09:00",
+          status: "failed",
+          failureReason: "Beacon not found",
+        },
+        manualRequest: makeManualRequestFixture({
+          id: "manual_request",
+        }),
+      }),
+      makeTodayItem({
+        employee: {
           id: "emp_102",
           name: "Failed Attempt",
           department: "Operations",
@@ -200,6 +225,9 @@ describe("groupAdminAttendanceTodayRows", () => {
       }),
     ]);
 
+    expect(grouped.previousDayOpen.map((item) => item.employee.id)).toEqual([
+      "emp_101",
+    ]);
     expect(grouped.failedAttempts.map((item) => item.employee.id)).toEqual([
       "emp_102",
     ]);

--- a/tests/unit/admin-attendance-routes.test.ts
+++ b/tests/unit/admin-attendance-routes.test.ts
@@ -121,6 +121,9 @@ describe("admin attendance route handlers", () => {
     expect(body.summary.checkedInCount).toBe(
       body.items.filter((item) => item.todayRecord !== null).length,
     );
+    expect(body.summary.previousDayOpenCount).toBe(
+      body.items.filter((item) => item.previousDayOpenRecord !== null).length,
+    );
     expect(body.summary.failedAttemptCount).toBe(
       body.items.filter((item) => item.latestFailedAttempt !== null).length,
     );
@@ -138,6 +141,14 @@ describe("admin attendance route handlers", () => {
       ).length,
     );
 
+    const carryOverRow = body.items.find(
+      (item) => item.previousDayOpenRecord !== null,
+    );
+
+    expect(carryOverRow).toBeDefined();
+    expect(carryOverRow?.previousDayOpenRecord?.date).toBe("2026-04-10");
+    expect(carryOverRow?.manualRequest).toBeNull();
+
     const activeManualRequestRow = body.items.find(
       (item) => item.manualRequest !== null,
     );
@@ -154,32 +165,33 @@ describe("admin attendance route handlers", () => {
     expect(approvedWritebackRow?.manualRequest).toBeNull();
   });
 
-  it("keeps same-day manual request dates on the matching today row", async () => {
-    const seededManualRequestRow = seededRepository
+  it("preserves a prior-workday manual request date on the carry-over row when the prior workday still governs the today surface", async () => {
+    const carryOverRow = seededRepository
       .getAdminAttendanceToday({
         date: baselineDate,
       })
-      .items.find((item) => item.employee.id === "emp_010");
+      .items.find((item) => item.previousDayOpenRecord !== null);
 
-    expect(seededManualRequestRow).toBeDefined();
-    expect(seededManualRequestRow?.manualRequest?.date).toBe("2026-04-13");
+    expect(carryOverRow).toBeDefined();
+    expect(carryOverRow?.employee.id).toBe("emp_001");
+    expect(carryOverRow?.previousDayOpenRecord?.date).toBe("2026-04-10");
 
     const modifiedWorld = structuredClone(canonicalSeedWorld);
 
     modifiedWorld.manualAttendanceRequests.push({
-      id: "manual_request_emp_001_2026-04-13_root",
+      id: "manual_request_emp_001_2026-04-10_root",
       employeeId: "emp_001",
       requestType: "manual_attendance",
       action: "clock_in",
-      date: "2026-04-13",
-      submittedAt: "2026-04-13T12:30:00+09:00",
-      requestedClockInAt: "2026-04-13T09:04:00+09:00",
+      date: "2026-04-10",
+      submittedAt: "2026-04-10T12:30:00+09:00",
+      requestedClockInAt: "2026-04-10T09:04:00+09:00",
       requestedClockOutAt: null,
-      reason: "Same-day manual request should stay on the same row.",
+      reason: "Prior-day checkout is still being resolved.",
       status: "pending",
       reviewedAt: null,
       reviewComment: null,
-      rootRequestId: "manual_request_emp_001_2026-04-13_root",
+      rootRequestId: "manual_request_emp_001_2026-04-10_root",
       parentRequestId: null,
       followUpKind: null,
       supersededByRequestId: null,
@@ -203,13 +215,14 @@ describe("admin attendance route handlers", () => {
       "Fetched admin attendance today",
     );
 
-    const updatedManualRequestRow = body.items.find(
+    const updatedCarryOverRow = body.items.find(
       (item) => item.employee.id === "emp_001",
     );
 
-    expect(updatedManualRequestRow).toBeDefined();
-    expect(updatedManualRequestRow?.manualRequest?.date).toBe("2026-04-13");
-    expect(updatedManualRequestRow?.manualRequest?.status).toBe("pending");
+    expect(updatedCarryOverRow).toBeDefined();
+    expect(updatedCarryOverRow?.previousDayOpenRecord?.date).toBe("2026-04-10");
+    expect(updatedCarryOverRow?.manualRequest?.date).toBe("2026-04-10");
+    expect(updatedCarryOverRow?.manualRequest?.status).toBe("pending");
   });
 
   it("returns the seeded admin list payload for a valid name filter, logs one fetch event, and keeps attendance-history rows free of embedded carry-over projections", async () => {
@@ -255,6 +268,9 @@ describe("admin attendance route handlers", () => {
     expect(body.records.every((record) => !("manualRequest" in record))).toBe(
       true,
     );
+    expect(
+      body.records.every((record) => !("previousDayOpenRecord" in record)),
+    ).toBe(true);
   });
 
   it.each([

--- a/tests/unit/api-contracts.test.ts
+++ b/tests/unit/api-contracts.test.ts
@@ -54,6 +54,7 @@ describe("shared contract schemas", () => {
       "attempt_failed",
       "not_checked_in",
       "absent",
+      "previous_day_checkout_missing",
       "leave_work_conflict",
       "manual_request_pending",
       "manual_request_rejected",
@@ -62,6 +63,7 @@ describe("shared contract schemas", () => {
       "clock_in",
       "clock_out",
       "submit_manual_request",
+      "resolve_previous_day_checkout",
       "review_request_status",
       "review_leave_conflict",
       "wait",
@@ -1449,6 +1451,7 @@ describe("admin attendance contracts", () => {
           lateCount: 1,
           onLeaveCount: 1,
           failedAttemptCount: 1,
+          previousDayOpenCount: 1,
         },
         items: [
           {
@@ -1485,6 +1488,7 @@ describe("admin attendance contracts", () => {
               },
             },
             latestFailedAttempt: null,
+            previousDayOpenRecord: null,
             manualRequest: null,
           },
         ],
@@ -1507,6 +1511,7 @@ describe("admin attendance contracts", () => {
           lateCount: 1,
           onLeaveCount: 1,
           failedAttemptCount: 1,
+          previousDayOpenCount: 1,
         },
         items: [
           {
@@ -1542,6 +1547,7 @@ describe("admin attendance contracts", () => {
               status: "success",
               failureReason: null,
             },
+            previousDayOpenRecord: null,
             manualRequest: null,
           },
         ],
@@ -1559,6 +1565,7 @@ describe("admin attendance contracts", () => {
           lateCount: 1,
           onLeaveCount: 1,
           failedAttemptCount: 1,
+          previousDayOpenCount: 1,
         },
         items: [
           {
@@ -1587,6 +1594,7 @@ describe("admin attendance contracts", () => {
               },
             },
             latestFailedAttempt: null,
+            previousDayOpenRecord: null,
             manualRequest: {
               id: "req_manual_001",
               requestType: "manual_attendance",

--- a/tests/unit/seed-repository.test.ts
+++ b/tests/unit/seed-repository.test.ts
@@ -163,7 +163,7 @@ describe("seed repository", () => {
     expect(parsedListResponse.filters).toEqual({
       name: "minji",
     });
-    expect(parsedListResponse.total).toBe(3);
+    expect(parsedListResponse.total).toBe(4);
     expect(parsedListResponse.records).toEqual(
       expect.arrayContaining([
         expect.objectContaining({


### PR DESCRIPTION
## Summary
- restore `/admin/attendance` to the recovered `#102` dashboard flow on top of current `main`
- keep `/admin/attendance/requests` unchanged
- reintroduce the admin carry-over projection needed for the top exception table, one-row summary cards, and full-team ledger views

## What Changed
- restored the recovered admin attendance screen components, page state, and today exception row builder
- restored admin-only carry-over fields in the admin attendance contract and repository projection
- kept the current employee and requests flows intact while re-adding the shared carry-over enum vocabulary needed by the restored admin view
- updated API/schema docs and admin regression tests to match the recovered behavior

## Verification
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`